### PR TITLE
Fix CreateClaimableBalanceSuccess.BalanceId 

### DIFF
--- a/StellarDotnetSdk.Tests/LedgerKeyTest.cs
+++ b/StellarDotnetSdk.Tests/LedgerKeyTest.cs
@@ -88,7 +88,7 @@ public class LedgerKeyTest
     [TestMethod]
     public void TestLedgerKeyClaimableBalanceStringConstructorValid()
     {
-        const string balanceId = "d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780";
+        const string balanceId = "00000000d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780";
         var ledgerKey = LedgerKey.ClaimableBalance(balanceId);
 
         // Act
@@ -96,24 +96,30 @@ public class LedgerKeyTest
         var decodedLedgerKey = (LedgerKeyClaimableBalance)LedgerKey.FromXdrBase64(ledgerKeyXdrBase64);
 
         // Assert
-        Assert.AreEqual("d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780",
+        Assert.AreEqual("00000000d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780",
             decodedLedgerKey.BalanceId.ToLower());
     }
 
     [TestMethod]
-    public void TestLedgerKeyClaimableBalanceStringConstructorInvalid()
+    public void TestLedgerKeyClaimableBalanceV0StringConstructorValid()
     {
-        const string balanceId = "00000000d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780";
-        var ex = Assert.ThrowsException<ArgumentException>(() =>
-            LedgerKey.ClaimableBalance(balanceId));
-        Assert.IsTrue(ex.Message.Contains("Claimable balance ID cannot exceed 64 characters."));
+        const string balanceId = "d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780";
+        var ledgerKey = LedgerKeyClaimableBalance.FromBalanceIdV0(balanceId);
+
+        // Act
+        var ledgerKeyXdrBase64 = ledgerKey.ToXdrBase64();
+        var decodedLedgerKey = (LedgerKeyClaimableBalance)LedgerKey.FromXdrBase64(ledgerKeyXdrBase64);
+
+        // Assert
+        Assert.AreEqual("00000000d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780",
+            decodedLedgerKey.BalanceId.ToLower());
     }
-    
+
     [TestMethod]
     public void TestLedgerKeyClaimableBalanceByteArrayConstructorValid()
     {
-        const string balanceId = "d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780";
-        var ledgerKey = LedgerKey.ClaimableBalance(Convert.FromHexString(balanceId));
+        const string balanceId = "00000000d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780";
+        var ledgerKey = LedgerKey.ClaimableBalance(balanceId);
 
         // Act
         var ledgerKeyXdrBase64 = ledgerKey.ToXdrBase64();
@@ -122,16 +128,7 @@ public class LedgerKeyTest
         // Assert
         Assert.AreEqual(balanceId, decodedLedgerKey.BalanceId.ToLower());
     }
-    
-    [TestMethod]
-    public void TestLedgerKeyClaimableBalanceByteArrayConstructorInvalid()
-    {
-        const string balanceId = "00000000d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780";
-        var ex = Assert.ThrowsException<ArgumentException>(() =>
-            LedgerKey.ClaimableBalance(Convert.FromHexString(balanceId)));
-        Assert.IsTrue(ex.Message.Contains("Claimable balance ID byte array must have exactly 32 bytes."));
-    }
-    
+
     [TestMethod]
     public void TestLedgerKeyLiquidityPool()
     {

--- a/StellarDotnetSdk.Tests/Operations/OperationTest.cs
+++ b/StellarDotnetSdk.Tests/Operations/OperationTest.cs
@@ -733,13 +733,13 @@ public class OperationTest
     {
         var operation =
             RevokeLedgerEntrySponsorshipOperation.ForClaimableBalance(
-                "d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780");
+                "00000000929b20b72e5890ab51c24f1cc46fa01c4f318d8d33367d24dd614cfdf5491072");
 
         var xdrOperation = operation.ToXdr();
         var decodedOperation = (RevokeLedgerEntrySponsorshipOperation)Operation.FromXdr(xdrOperation);
 
         Assert.IsNull(decodedOperation.SourceAccount);
-        Assert.AreEqual(((LedgerKeyClaimableBalance)operation.LedgerKey).BalanceId,
+        Assert.AreEqual(((LedgerKeyClaimableBalance)operation.LedgerKey).BalanceId.ToLower(),
             ((LedgerKeyClaimableBalance)decodedOperation.LedgerKey).BalanceId.ToLower());
     }
 

--- a/StellarDotnetSdk.Tests/SorobanServerTest.cs
+++ b/StellarDotnetSdk.Tests/SorobanServerTest.cs
@@ -772,7 +772,7 @@ public class SorobanServerTest
         var ledgerKey = response.LedgerKeys[0] as LedgerKeyClaimableBalance;
         Assert.IsNotNull(ledgerEntry);
         Assert.IsNotNull(ledgerKey);
-        Assert.AreEqual("299a32106238f3b2d84d4142783fe320253bcda775d1bfb7accdb533021ddccf",
+        Assert.AreEqual("00000000299a32106238f3b2d84d4142783fe320253bcda775d1bfb7accdb533021ddccf",
             ledgerKey.BalanceId.ToLower());
         Assert.AreEqual(457593U, ledgerEntry.LastModifiedLedgerSeq);
         Assert.AreEqual("native", ledgerEntry.Asset.Type);

--- a/StellarDotnetSdk/LedgerKeys/LedgerKey.cs
+++ b/StellarDotnetSdk/LedgerKeys/LedgerKey.cs
@@ -17,16 +17,26 @@ public abstract class LedgerKey
         return new LedgerKeyAccount(account);
     }
 
-    public static LedgerKey ClaimableBalance(byte[] balanceId)
+    [Obsolete("Deprecated. Use ClaimableBalance(string balanceIdHexString) instead.")]
+    /// <summary>
+    ///     Constructs a <c>LedgerKeyClaimableBalance</c> object from a 32-byte array representation of a Claimable balance ID v0.
+    /// </summary>
+    /// <param name="balanceIdV0ByteArray">Byte array representation of the claimable balance ID v0.</param>
+    public static LedgerKey ClaimableBalance(byte[] balanceIdV0ByteArray)
     {
-        return new LedgerKeyClaimableBalance(balanceId);
+        return new LedgerKeyClaimableBalance(balanceIdV0ByteArray);
     }
 
     /// <summary>Constructs a new <c>LedgerKeyClaimableBalance</c> from the given hex-encoded claimable balance ID.</summary>
     /// <param name="balanceIdHexString">
     ///     Hex-encoded ID of the claimable balance entry.
-    ///     For example: <c>d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780</c>.
+    ///     For example: <c>00000000d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780</c>.
     /// </param>
+    /// <remarks>
+    ///     Balance ID and Balance ID v0 are not the same. The v0 values don't have 8 leading zeros.
+    ///     For example, if balance ID is 00000000d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780,
+    ///     then balance ID v0 is d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780.
+    /// </remarks>
     public static LedgerKey ClaimableBalance(string balanceIdHexString)
     {
         return new LedgerKeyClaimableBalance(balanceIdHexString);

--- a/StellarDotnetSdk/LedgerKeys/LedgerKeyClaimableBalance.cs
+++ b/StellarDotnetSdk/LedgerKeys/LedgerKeyClaimableBalance.cs
@@ -5,17 +5,33 @@ namespace StellarDotnetSdk.LedgerKeys;
 
 public class LedgerKeyClaimableBalance : LedgerKey
 {
-    /// <summary>
-    ///     Constructs a <c>LedgerKeyClaimableBalance</c> object from a 32-byte array.
-    /// </summary>
-    /// <param name="balanceIdByteArray">Byte array representation of the claimable balance entry.</param>
-    public LedgerKeyClaimableBalance(byte[] balanceIdByteArray)
+    private readonly ClaimableBalanceID _xdrClaimableBalanceId;
+
+    private LedgerKeyClaimableBalance(ClaimableBalanceID xdrClaimableBalanceId)
     {
-        if (balanceIdByteArray.Length != 32)
+        _xdrClaimableBalanceId = xdrClaimableBalanceId;
+    }
+
+    /// <summary>
+    ///     Constructs a <c>LedgerKeyClaimableBalance</c> object from a 32-byte array representation of a Claimable balance ID
+    ///     v0.
+    /// </summary>
+    /// <param name="balanceIdV0ByteArray">Byte array representation of the claimable balance ID v0.</param>
+    public LedgerKeyClaimableBalance(byte[] balanceIdV0ByteArray)
+    {
+        if (balanceIdV0ByteArray.Length != 32)
         {
-            throw new ArgumentException("Claimable balance ID byte array must have exactly 32 bytes.", nameof(balanceIdByteArray));
+            throw new ArgumentException("Claimable balance ID V0 byte array must have exactly 32 bytes.",
+                nameof(balanceIdV0ByteArray));
         }
-        BalanceId = Convert.ToHexString(balanceIdByteArray);
+        _xdrClaimableBalanceId = new ClaimableBalanceID
+        {
+            Discriminant = new ClaimableBalanceIDType
+            {
+                InnerValue = ClaimableBalanceIDType.ClaimableBalanceIDTypeEnum.CLAIMABLE_BALANCE_ID_TYPE_V0,
+            },
+            V0 = new Hash(balanceIdV0ByteArray),
+        };
     }
 
     /// <summary>
@@ -23,35 +39,65 @@ public class LedgerKeyClaimableBalance : LedgerKey
     /// </summary>
     /// <param name="balanceIdHexString">
     ///     Hex-encoded ID of the claimable balance entry.
-    ///     For example: <c>d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780</c>.
+    ///     For example: <c>00000000d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780</c>.
     /// </param>
     public LedgerKeyClaimableBalance(string balanceIdHexString)
     {
-        if (balanceIdHexString.Length > 64)
-        {
-            throw new ArgumentException("Claimable balance ID cannot exceed 64 characters.", nameof(balanceIdHexString));
-        }
-        BalanceId = balanceIdHexString;
+        var bytes = Convert.FromHexString(balanceIdHexString);
+        var inputStream = new XdrDataInputStream(bytes);
+        _xdrClaimableBalanceId = ClaimableBalanceID.Decode(inputStream);
     }
 
-    public string BalanceId { get; }
+    /// <summary>
+    ///     Hex-encoded ID of the claimable balance entry.
+    ///     For example: <c>00000000d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780</c>.
+    /// </summary>
+    public string BalanceId
+    {
+        get
+        {
+            var outputStream = new XdrDataOutputStream();
+            ClaimableBalanceID.Encode(outputStream, _xdrClaimableBalanceId);
+            return Convert.ToHexString(outputStream.ToArray());
+        }
+    }
+
+    /// <summary>
+    ///     Constructs a <c>LedgerKeyClaimableBalance</c> from given hex-encoded claimable balance ID v0.
+    /// </summary>
+    /// <param name="balanceIdV0">
+    ///     Hex-encoded ID of the claimable balance v0 entry.
+    ///     For example: <c>d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780</c>.
+    /// </param>
+    /// <remarks>
+    ///     Balance ID and Balance ID v0 are not the same. The v0 values don't have 8 leading zeros.
+    ///     For example, if balance ID is 00000000d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780,
+    ///     then balance ID v0 is d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780.
+    /// </remarks>
+    public static LedgerKeyClaimableBalance FromBalanceIdV0(string balanceIdV0)
+    {
+        var xdrClaimableBalanceId = new ClaimableBalanceID
+        {
+            Discriminant = new ClaimableBalanceIDType
+            {
+                InnerValue = ClaimableBalanceIDType.ClaimableBalanceIDTypeEnum.CLAIMABLE_BALANCE_ID_TYPE_V0,
+            },
+            V0 = new Hash(Convert.FromHexString(balanceIdV0)),
+        };
+        return new LedgerKeyClaimableBalance(xdrClaimableBalanceId);
+    }
 
     public override Xdr.LedgerKey ToXdr()
     {
         return new Xdr.LedgerKey
         {
-            Discriminant =
-                new LedgerEntryType { InnerValue = LedgerEntryType.LedgerEntryTypeEnum.CLAIMABLE_BALANCE },
+            Discriminant = new LedgerEntryType
+            {
+                InnerValue = LedgerEntryType.LedgerEntryTypeEnum.CLAIMABLE_BALANCE,
+            },
             ClaimableBalance = new Xdr.LedgerKey.LedgerKeyClaimableBalance
             {
-                BalanceID = new ClaimableBalanceID
-                {
-                    Discriminant = new ClaimableBalanceIDType
-                    {
-                        InnerValue = ClaimableBalanceIDType.ClaimableBalanceIDTypeEnum.CLAIMABLE_BALANCE_ID_TYPE_V0,
-                    },
-                    V0 = new Hash(Convert.FromHexString(BalanceId)),
-                },
+                BalanceID = _xdrClaimableBalanceId,
             },
         };
     }


### PR DESCRIPTION
Fix CreateClaimableBalanceSuccess.BalanceId returning a different value than in other SDKs (https://github.com/Beans-BV/dotnet-stellar-sdk/issues/46)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
