### PR TITLE
chore: improve ClaimableBalanceId

### DIFF
--- a/StellarDotnetSdk.Tests/ClaimableBalanceUtilsTest.cs
+++ b/StellarDotnetSdk.Tests/ClaimableBalanceUtilsTest.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StellarDotnetSdk.Xdr;
+
+namespace StellarDotnetSdk.Tests;
+
+[TestClass]
+public class ClaimableBalanceUtilsTest
+{
+    [TestMethod]
+    [DataRow("299a32106238f3b2d84d4142783fe320253bcda775d1bfb7accdb533021ddccf",
+        "BAACTGRSCBRDR45S3BGUCQTYH7RSAJJ3ZWTXLUN7W6WM3NJTAIO5ZT2U6I")]
+    public void TestFromXdr(string hex, string base32)
+    {
+        var xdrClaimableBalanceId = new ClaimableBalanceID
+        {
+            Discriminant =
+                ClaimableBalanceIDType.Create(ClaimableBalanceIDType.ClaimableBalanceIDTypeEnum
+                    .CLAIMABLE_BALANCE_ID_TYPE_V0),
+            V0 = new Hash(Convert.FromHexString(hex)),
+        };
+        var id = ClaimableBalanceUtils.FromXdr(xdrClaimableBalanceId);
+        Assert.AreEqual(id, base32);
+    }
+
+    [TestMethod]
+    [DataRow("BAACTGRSCBRDR45S3BGUCQTYH7RSAJJ3ZWTXLUN7W6WM3NJTAIO5ZT2U6I",
+        "00000000299a32106238f3b2d84d4142783fe320253bcda775d1bfb7accdb533021ddccf")]
+    public void TestToHexString(string input, string output)
+    {
+        var hex = ClaimableBalanceUtils.ToHexString(input).ToLower();
+        Assert.AreEqual(output, hex);
+    }
+
+    [TestMethod]
+    [DataRow("00000000299a32106238f3b2d84d4142783fe320253bcda775d1bfb7accdb533021ddccf",
+        "BAACTGRSCBRDR45S3BGUCQTYH7RSAJJ3ZWTXLUN7W6WM3NJTAIO5ZT2U6I")]
+    public void TestToBase32String(string input, string output)
+    {
+        var base32 = ClaimableBalanceUtils.ToBase32String(input);
+        Assert.AreEqual(output, base32);
+    }
+}

--- a/StellarDotnetSdk.Tests/LedgerEntryChangeTest.cs
+++ b/StellarDotnetSdk.Tests/LedgerEntryChangeTest.cs
@@ -2,17 +2,13 @@ using System;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using StellarDotnetSdk.Accounts;
-using StellarDotnetSdk.Assets;
 using StellarDotnetSdk.LedgerEntries;
 using StellarDotnetSdk.LedgerKeys;
-using StellarDotnetSdk.LiquidityPool;
-using StellarDotnetSdk.Soroban;
 using StellarDotnetSdk.Xdr;
 using XdrLedgerEntry = StellarDotnetSdk.Xdr.LedgerEntry;
 using LedgerEntryChange = StellarDotnetSdk.Xdr.LedgerEntryChange;
-using LedgerKey = StellarDotnetSdk.LedgerKeys.LedgerKey;
-using SCSymbol = StellarDotnetSdk.Soroban.SCSymbol;
 using LedgerEntryChangeTypeEnum = StellarDotnetSdk.Xdr.LedgerEntryChangeType.LedgerEntryChangeTypeEnum;
+using LedgerKey = StellarDotnetSdk.Xdr.LedgerKey;
 
 namespace StellarDotnetSdk.Tests;
 
@@ -122,10 +118,10 @@ public class LedgerEntryChangeTest
         {
             Discriminant =
                 LedgerEntryChangeType.Create(LedgerEntryChangeTypeEnum.LEDGER_ENTRY_REMOVED),
-            Removed = new StellarDotnetSdk.Xdr.LedgerKey
+            Removed = new LedgerKey
             {
                 Discriminant = LedgerEntryType.Create(LedgerEntryType.LedgerEntryTypeEnum.ACCOUNT),
-                Account = new StellarDotnetSdk.Xdr.LedgerKey.LedgerKeyAccount
+                Account = new LedgerKey.LedgerKeyAccount
                 {
                     AccountID = new AccountID(KeyPair.Random().XdrPublicKey),
                 },
@@ -183,222 +179,5 @@ public class LedgerEntryChangeTest
                 },
             },
         };
-    }
-
-    [TestMethod]
-    public void TestLedgerKeyDataWithTooLongName()
-    {
-        var keypair = KeyPair.FromAccountId("GCFRHRU5YRI3IN3IMRMYGWWEG2PX2B6MYH2RJW7NEDE2PTYPISPT3RU7");
-        const string dataName = "This is a 73 characters long string which is too strong for String64 type";
-        var ex = Assert.ThrowsException<ArgumentException>(() => LedgerKey.Data(keypair, dataName));
-        Assert.IsTrue(ex.Message.Contains("Data name cannot exceed 64 characters."));
-    }
-
-    [TestMethod]
-    public void TestLedgerKeyDataWithValidName()
-    {
-        var keypair = KeyPair.FromAccountId("GCFRHRU5YRI3IN3IMRMYGWWEG2PX2B6MYH2RJW7NEDE2PTYPISPT3RU7");
-        var ledgerKey = (LedgerKeyData)LedgerKey.Data(keypair, "Test Data");
-
-        // Act
-        var ledgerKeyXdrBase64 = ledgerKey.ToXdrBase64();
-        var decodedLedgerKey = (LedgerKeyData)LedgerKey.FromXdrBase64(ledgerKeyXdrBase64);
-
-        // Assert
-        Assert.AreEqual(ledgerKey.DataName, decodedLedgerKey.DataName);
-        Assert.AreEqual(ledgerKey.Account.AccountId, decodedLedgerKey.Account.AccountId);
-    }
-
-    [TestMethod]
-    public void TestLedgerKeyOffer()
-    {
-        var keypair = KeyPair.FromAccountId("GCFRHRU5YRI3IN3IMRMYGWWEG2PX2B6MYH2RJW7NEDE2PTYPISPT3RU7");
-        var ledgerKey = (LedgerKeyOffer)LedgerKey.Offer(keypair, 1234);
-
-        // Act
-        var ledgerKeyXdrBase64 = ledgerKey.ToXdrBase64();
-        var decodedLedgerKey = (LedgerKeyOffer)LedgerKey.FromXdrBase64(ledgerKeyXdrBase64);
-
-        // Assert
-        Assert.AreEqual(ledgerKey.OfferId, decodedLedgerKey.OfferId);
-        Assert.AreEqual(ledgerKey.Seller.AccountId, decodedLedgerKey.Seller.AccountId);
-    }
-
-    [TestMethod]
-    public void TestLedgerKeyTrustline()
-    {
-        var keypair = KeyPair.FromAccountId("GCFRHRU5YRI3IN3IMRMYGWWEG2PX2B6MYH2RJW7NEDE2PTYPISPT3RU7");
-        var issuer = KeyPair.FromAccountId("GB24C27VKWCBG7NTCT4J2L4MXJGYC3K3SQ4JOTCSPOVVEN7EZEB43XNE");
-        var asset = TrustlineAsset.CreateNonNativeAsset("ABCD", issuer.AccountId);
-        var ledgerKey = LedgerKey.Trustline(keypair, asset);
-
-        // Act
-        var ledgerKeyXdrBase64 = ledgerKey.ToXdrBase64();
-        var decodedLedgerKey = (LedgerKeyTrustline)LedgerKey.FromXdrBase64(ledgerKeyXdrBase64);
-
-        // Assert
-        Assert.AreEqual("ABCD:GB24C27VKWCBG7NTCT4J2L4MXJGYC3K3SQ4JOTCSPOVVEN7EZEB43XNE",
-            ((TrustlineAsset.Wrapper)decodedLedgerKey.Asset).Asset.CanonicalName());
-        Assert.AreEqual(keypair.AccountId, decodedLedgerKey.Account.AccountId);
-    }
-
-    [TestMethod]
-    public void TestLedgerKeyClaimableBalanceStringConstructorValid()
-    {
-        const string balanceId = "d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780";
-        var ledgerKey = LedgerKey.ClaimableBalance(balanceId);
-
-        // Act
-        var ledgerKeyXdrBase64 = ledgerKey.ToXdrBase64();
-        var decodedLedgerKey = (LedgerKeyClaimableBalance)LedgerKey.FromXdrBase64(ledgerKeyXdrBase64);
-
-        // Assert
-        Assert.AreEqual("d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780",
-            decodedLedgerKey.BalanceId.ToLower());
-    }
-
-    [TestMethod]
-    public void TestLedgerKeyClaimableBalanceStringConstructorInvalid()
-    {
-        const string balanceId = "00000000d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780";
-        var ex = Assert.ThrowsException<ArgumentException>(() =>
-            LedgerKey.ClaimableBalance(balanceId));
-        Assert.IsTrue(ex.Message.Contains("Claimable balance ID cannot exceed 64 characters."));
-    }
-
-    [TestMethod]
-    public void TestLedgerKeyClaimableBalanceByteArrayConstructorValid()
-    {
-        const string balanceId = "d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780";
-        var ledgerKey = LedgerKey.ClaimableBalance(Convert.FromHexString(balanceId));
-
-        // Act
-        var ledgerKeyXdrBase64 = ledgerKey.ToXdrBase64();
-        var decodedLedgerKey = (LedgerKeyClaimableBalance)LedgerKey.FromXdrBase64(ledgerKeyXdrBase64);
-
-        // Assert
-        Assert.AreEqual(balanceId, decodedLedgerKey.BalanceId.ToLower());
-    }
-
-    [TestMethod]
-    public void TestLedgerKeyClaimableBalanceByteArrayConstructorInvalid()
-    {
-        const string balanceId = "00000000d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780";
-        var ex = Assert.ThrowsException<ArgumentException>(() =>
-            LedgerKey.ClaimableBalance(Convert.FromHexString(balanceId)));
-        Assert.IsTrue(ex.Message.Contains("Claimable balance ID byte array must have exactly 32 bytes."));
-    }
-
-    [TestMethod]
-    public void TestLedgerKeyLiquidityPool()
-    {
-        var hash = new byte[]
-            { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2 };
-        var ledgerKey = LedgerKey.LiquidityPool(new LiquidityPoolId(hash));
-
-        // Act
-        var ledgerKeyXdrBase64 = ledgerKey.ToXdrBase64();
-        var decodedLedgerKey = (LedgerKeyLiquidityPool)LedgerKey.FromXdrBase64(ledgerKeyXdrBase64);
-
-        // Assert
-        CollectionAssert.AreEqual(hash, decodedLedgerKey.LiquidityPoolId.Hash);
-    }
-
-    [TestMethod]
-    public void TestLedgerKeyContractDataWithContractBeingContractId()
-    {
-        var contractId = new ScContractId("CAC2UYJQMC4ISUZ5REYB2AMDC44YKBNZWG4JB6N6GBL66CEKQO3RDSAB");
-        var key = new SCSymbol("kk");
-
-        var durability = ContractDataDurability.Create(ContractDataDurability.ContractDataDurabilityEnum.PERSISTENT);
-        var ledgerKey = (LedgerKeyContractData)LedgerKey.ContractData(contractId, key, durability);
-
-        // Act
-        var ledgerKeyXdrBase64 = ledgerKey.ToXdrBase64();
-        var decodedLedgerKey = (LedgerKeyContractData)LedgerKey.FromXdrBase64(ledgerKeyXdrBase64);
-
-        // Assert
-        Assert.AreEqual(contractId.InnerValue, ((ScContractId)decodedLedgerKey.Contract).InnerValue);
-        Assert.AreEqual(key.InnerValue, ((SCSymbol)decodedLedgerKey.Key).InnerValue);
-        Assert.AreEqual(ledgerKey.Durability.InnerValue, decodedLedgerKey.Durability.InnerValue);
-    }
-
-    [TestMethod]
-    public void TestLedgerKeyContractDataWithWithContractBeingAccountId()
-    {
-        var accountId = new ScAccountId("GCZFMH32MF5EAWETZTKF3ZV5SEVJPI53UEMDNSW55WBR75GMZJU4U573");
-        var key = new SCInt64(122);
-
-        var durability = ContractDataDurability.Create(ContractDataDurability.ContractDataDurabilityEnum.TEMPORARY);
-        var ledgerKey = (LedgerKeyContractData)LedgerKey.ContractData(accountId, key, durability);
-
-        // Act
-        var ledgerKeyXdrBase64 = ledgerKey.ToXdrBase64();
-        var decodedLedgerKey = (LedgerKeyContractData)LedgerKey.FromXdrBase64(ledgerKeyXdrBase64);
-
-        // Assert
-        Assert.AreEqual(accountId.InnerValue, ((ScAccountId)decodedLedgerKey.Contract).InnerValue);
-        Assert.AreEqual(key.InnerValue, ((SCInt64)decodedLedgerKey.Key).InnerValue);
-        Assert.AreEqual(ledgerKey.Durability.InnerValue, decodedLedgerKey.Durability.InnerValue);
-    }
-
-    [TestMethod]
-    public void TestLedgerKeyContractCodeCreationFromValidHashString()
-    {
-        var ledgerKey =
-            (LedgerKeyContractCode)LedgerKey.ContractCode(
-                "0102030405060708090001020304050607080900010203040506070809000102");
-
-        // Act
-        var ledgerKeyXdrBase64 = ledgerKey.ToXdrBase64();
-        var decodedLedgerKey = (LedgerKeyContractCode)LedgerKey.FromXdrBase64(ledgerKeyXdrBase64);
-
-        // Assert
-        CollectionAssert.AreEqual(ledgerKey.Hash, decodedLedgerKey.Hash);
-    }
-
-    [TestMethod]
-    public void TestLedgerKeyContractCodeCreationFromInvalidHashString()
-    {
-        var ex = Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-            LedgerKey.ContractCode("01020304050607080900010203040506070809000102030405060708090002"));
-        Assert.IsTrue(ex.Message.Contains("Hash must have exactly 32 bytes."));
-    }
-
-    [TestMethod]
-    public void TestLedgerKeyConfigSetting()
-    {
-        var ledgerKey = (LedgerKeyConfigSetting)LedgerKey.ConfigSetting(new ConfigSettingID
-        {
-            InnerValue = ConfigSettingID.ConfigSettingIDEnum.CONFIG_SETTING_STATE_ARCHIVAL,
-        });
-
-        // Act
-        var ledgerKeyXdrBase64 = ledgerKey.ToXdrBase64();
-        var decodedLedgerKey = (LedgerKeyConfigSetting)LedgerKey.FromXdrBase64(ledgerKeyXdrBase64);
-
-        // Assert
-        Assert.AreEqual(ledgerKey.ConfigSettingId.InnerValue, decodedLedgerKey.ConfigSettingId.InnerValue);
-    }
-
-    [TestMethod]
-    public void TestLedgerKeyTtlCreationFromValidHashString()
-    {
-        var ledgerKey = (LedgerKeyTtl)LedgerKey.Ttl("AQIDBAUGBwgJAAECAwQFBgcICQABAgMEBQYHCAkAAQI=");
-
-        // Act
-        var ledgerKeyXdrBase64 = ledgerKey.ToXdrBase64();
-        var decodedLedgerKey = (LedgerKeyTtl)LedgerKey.FromXdrBase64(ledgerKeyXdrBase64);
-
-        // Assert
-        CollectionAssert.AreEqual(ledgerKey.Key, decodedLedgerKey.Key);
-    }
-
-    [TestMethod]
-    public void TestLedgerKeyTtlCreationFromInvalidHashString()
-    {
-        var ex = Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-            LedgerKey.ContractCode("01020304050607080900010203040506070809000102030405060708090001020304"));
-        Assert.IsTrue(ex.Message.Contains("Hash must have exactly 32 bytes."));
     }
 }

--- a/StellarDotnetSdk.Tests/LedgerEntryTest.cs
+++ b/StellarDotnetSdk.Tests/LedgerEntryTest.cs
@@ -659,57 +659,6 @@ public class LedgerEntryTest
     }
 
     [TestMethod]
-    public void TestLedgerEntryClaimableBalanceWithTooLongBalanceId()
-    {
-        var xdrClaimableBalanceEntry = InitBasicXdrClaimableBalanceEntry();
-        xdrClaimableBalanceEntry.BalanceID = new ClaimableBalanceID
-        {
-            Discriminant =
-                ClaimableBalanceIDType.Create(ClaimableBalanceIDType.ClaimableBalanceIDTypeEnum
-                    .CLAIMABLE_BALANCE_ID_TYPE_V0),
-            V0 = new Hash(new byte[]
-                { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3 }),
-        };
-        var xdrLedgerEntryData = new StellarDotnetSdk.Xdr.LedgerEntry.LedgerEntryData
-        {
-            Discriminant = LedgerEntryType.Create(LedgerEntryType.LedgerEntryTypeEnum.CLAIMABLE_BALANCE),
-            ClaimableBalance = xdrClaimableBalanceEntry,
-        };
-        var os = new XdrDataOutputStream();
-        StellarDotnetSdk.Xdr.LedgerEntry.LedgerEntryData.Encode(os, xdrLedgerEntryData);
-        var entryXdrBase64 = Convert.ToBase64String(os.ToArray());
-        Assert.ThrowsException<Exception>(() => LedgerEntry.FromXdrBase64(entryXdrBase64));
-    }
-
-    [TestMethod]
-    public void TestLedgerEntryClaimableBalanceWithTooShortBalanceId()
-    {
-        var xdrClaimableBalanceEntry = InitBasicXdrClaimableBalanceEntry();
-        xdrClaimableBalanceEntry.BalanceID = new ClaimableBalanceID
-        {
-            Discriminant =
-                ClaimableBalanceIDType.Create(ClaimableBalanceIDType.ClaimableBalanceIDTypeEnum
-                    .CLAIMABLE_BALANCE_ID_TYPE_V0),
-            V0 = new Hash(new byte[]
-                { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1 }),
-        };
-        var xdrLedgerEntryData = new StellarDotnetSdk.Xdr.LedgerEntry.LedgerEntryData
-        {
-            Discriminant = LedgerEntryType.Create(LedgerEntryType.LedgerEntryTypeEnum.CLAIMABLE_BALANCE),
-            ClaimableBalance = xdrClaimableBalanceEntry,
-        };
-        var os = new XdrDataOutputStream();
-        StellarDotnetSdk.Xdr.LedgerEntry.LedgerEntryData.Encode(os, xdrLedgerEntryData);
-        var entryXdrBase64 = Convert.ToBase64String(os.ToArray());
-        var decodedLedgerEntry = (LedgerEntryClaimableBalance)LedgerEntry.FromXdrBase64(entryXdrBase64);
-        Assert.AreEqual(31, xdrClaimableBalanceEntry.BalanceID.V0.InnerValue.Length);
-        // Decoded BalanceId always has 32 bytes
-        Assert.AreEqual(32, decodedLedgerEntry.BalanceId.Length);
-        CollectionAssert.AreEqual(Util.PaddedByteArray(xdrClaimableBalanceEntry.BalanceID.V0.InnerValue, 32),
-            decodedLedgerEntry.BalanceId);
-    }
-
-    [TestMethod]
     public void TestLedgerEntryClaimableBalanceWithMissingClaimableBalanceExtension()
     {
         var xdrClaimableBalanceEntry = InitBasicXdrClaimableBalanceEntry();
@@ -739,7 +688,7 @@ public class LedgerEntryTest
                 decodedPredicate.Duration);
         }
 
-        CollectionAssert.AreEqual(xdrClaimableBalanceEntry.BalanceID.V0.InnerValue,
+        Assert.AreEqual(ClaimableBalanceUtils.FromXdr(xdrClaimableBalanceEntry.BalanceID),
             decodedLedgerEntry.BalanceId);
 
         Assert.AreEqual(xdrClaimableBalanceEntry.Amount.InnerValue,
@@ -793,8 +742,7 @@ public class LedgerEntryTest
             Assert.AreEqual(xdrClaimant.Predicate.RelBefore.InnerValue,
                 decodedPredicate.Duration);
         }
-
-        CollectionAssert.AreEqual(xdrClaimableBalanceEntry.BalanceID.V0.InnerValue,
+        Assert.AreEqual(ClaimableBalanceUtils.FromXdr(xdrClaimableBalanceEntry.BalanceID),
             decodedLedgerEntry.BalanceId);
 
         Assert.AreEqual(xdrClaimableBalanceEntry.Amount.InnerValue,

--- a/StellarDotnetSdk.Tests/LedgerKeyTest.cs
+++ b/StellarDotnetSdk.Tests/LedgerKeyTest.cs
@@ -86,50 +86,27 @@ public class LedgerKeyTest
     }
 
     [TestMethod]
-    public void TestLedgerKeyClaimableBalanceStringConstructorValid()
+    [DataRow("BAAKEZMZYI3VFSJMHZ2PMC3SBANQWP2LDKBVH42XQSHWTSBOH7TDOPHPFA")]
+    public void TestLedgerKeyClaimableBalanceStringConstructorValid(string id)
     {
-        const string balanceId = "d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780";
-        var ledgerKey = LedgerKey.ClaimableBalance(balanceId);
+        var ledgerKey = LedgerKey.ClaimableBalance(id);
 
         // Act
         var ledgerKeyXdrBase64 = ledgerKey.ToXdrBase64();
         var decodedLedgerKey = (LedgerKeyClaimableBalance)LedgerKey.FromXdrBase64(ledgerKeyXdrBase64);
 
         // Assert
-        Assert.AreEqual("d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780",
-            decodedLedgerKey.BalanceId.ToLower());
+        Assert.AreEqual(id, decodedLedgerKey.BalanceId);
     }
 
     [TestMethod]
-    public void TestLedgerKeyClaimableBalanceStringConstructorInvalid()
+    [ExpectedException(typeof(ArgumentException))]
+    [DataRow("00000000d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780")]
+    [DataRow("d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780")]
+    [DataRow("00d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780")]
+    public void TestLedgerKeyClaimableBalanceStringConstructorInvalid(string id)
     {
-        const string balanceId = "00000000d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780";
-        var ex = Assert.ThrowsException<ArgumentException>(() =>
-            LedgerKey.ClaimableBalance(balanceId));
-        Assert.IsTrue(ex.Message.Contains("Claimable balance ID cannot exceed 64 characters."));
-    }
-
-    [TestMethod]
-    public void TestLedgerKeyClaimableBalanceByteArrayConstructorValid()
-    {
-        const string balanceId = "d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780";
-        var ledgerKey = LedgerKey.ClaimableBalance(Convert.FromHexString(balanceId));
-
-        // Act
-        var ledgerKeyXdrBase64 = ledgerKey.ToXdrBase64();
-        var decodedLedgerKey = (LedgerKeyClaimableBalance)LedgerKey.FromXdrBase64(ledgerKeyXdrBase64);
-
-        // Assert
-        Assert.AreEqual(balanceId, decodedLedgerKey.BalanceId.ToLower());
-    }
-
-    [TestMethod]
-    public void TestLedgerKeyClaimableBalanceByteArrayConstructorInvalid()
-    {
-        const string balanceId = "00000000d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780";
-        var ex = Assert.ThrowsException<ArgumentException>(() =>
-            LedgerKey.ClaimableBalance(Convert.FromHexString(balanceId)));
-        Assert.IsTrue(ex.Message.Contains("Claimable balance ID byte array must have exactly 32 bytes."));
+        _ = LedgerKey.ClaimableBalance(id);
     }
 
     [TestMethod]

--- a/StellarDotnetSdk.Tests/Operations/OperationTest.cs
+++ b/StellarDotnetSdk.Tests/Operations/OperationTest.cs
@@ -616,23 +616,19 @@ public class OperationTest
             operation.ToXdrBase64());
     }
 
-    /// <summary>
-    ///     Claim a claimable balance using the string representation of the balance id.
-    /// </summary>
     [TestMethod]
-    [Obsolete]
-    public void TestClaimClaimableBalanceWithStringIdOperationValid()
+    [DataRow("000000006d6a0c142516a9cc7885a85c5aba3a1f4af5181cf9e7a809ac7ae5e4a58c825f")]
+    public void TestClaimClaimableBalanceOperationConstructorWithValidArgument(string id)
     {
-        var balanceId = "000000006d6a0c142516a9cc7885a85c5aba3a1f4af5181cf9e7a809ac7ae5e4a58c825f";
         var accountId = KeyPair.FromAccountId("GABTTS6N4CT7AUN4LD7IFIUMRD5PSMCW6QTLIQNEFZDEI6ZQVUCQMCLN");
-        var operation = new ClaimClaimableBalanceOperation(balanceId, accountId);
+        var operation = new ClaimClaimableBalanceOperation(id, accountId);
 
         var xdr = operation.ToXdr();
         var parsedOperation = (ClaimClaimableBalanceOperation)Operation.FromXdr(xdr);
         Assert.IsNotNull(operation.SourceAccount);
         Assert.IsNotNull(parsedOperation.SourceAccount);
         Assert.AreEqual(operation.SourceAccount.AccountId, parsedOperation.SourceAccount.AccountId);
-        Assert.AreEqual(operation.BalanceId, parsedOperation.BalanceId);
+        Assert.AreEqual(operation.BalanceId.ToUpper(), parsedOperation.BalanceId.ToUpper());
 
         Assert.AreEqual(
             "AAAAAQAAAAADOcvN4KfwUbxY/oKijIj6+TBW9Ca0QaQuRkR7MK0FBgAAAA8AAAAAbWoMFCUWqcx4hahcWro6H0r1GBz556gJrHrl5KWMgl8=",
@@ -640,24 +636,15 @@ public class OperationTest
     }
 
     [TestMethod]
-    public void TestClaimClaimableBalanceOperationInvalidEmptyBalanceId()
+    [ExpectedException(typeof(ArgumentException))]
+    [DataRow("")]
+    [DataRow("00000000")]
+    [DataRow("00846c047755e4a46912336f56096b48ece78ddb5fbf6d90f0eb4ecae5324fbddb")]
+    [DataRow("BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU")]
+    public void TestClaimClaimableBalanceOperationConstructorWithInvalidArgument(string id)
     {
-        var balanceId = "";
         var accountId = KeyPair.FromAccountId("GABTTS6N4CT7AUN4LD7IFIUMRD5PSMCW6QTLIQNEFZDEI6ZQVUCQMCLN");
-
-        Assert.ThrowsException<ArgumentException>(() => new ClaimClaimableBalanceOperation(balanceId, accountId));
-    }
-
-    /// <summary>
-    ///     The last 32 bytes of the balance id are the balance id body, this is required.
-    /// </summary>
-    [TestMethod]
-    public void TestClaimClaimableBalanceOperationInvalidClaimableBalanceIdBodyMissing()
-    {
-        var balanceId = "00000000";
-        var accountId = KeyPair.FromAccountId("GABTTS6N4CT7AUN4LD7IFIUMRD5PSMCW6QTLIQNEFZDEI6ZQVUCQMCLN");
-
-        Assert.ThrowsException<ArgumentException>(() => new ClaimClaimableBalanceOperation(balanceId, accountId));
+        _ = new ClaimClaimableBalanceOperation(id, accountId);
     }
 
     [TestMethod]
@@ -733,14 +720,14 @@ public class OperationTest
     {
         var operation =
             RevokeLedgerEntrySponsorshipOperation.ForClaimableBalance(
-                "d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780");
+                "00000000d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780");
 
         var xdrOperation = operation.ToXdr();
         var decodedOperation = (RevokeLedgerEntrySponsorshipOperation)Operation.FromXdr(xdrOperation);
 
         Assert.IsNull(decodedOperation.SourceAccount);
         Assert.AreEqual(((LedgerKeyClaimableBalance)operation.LedgerKey).BalanceId,
-            ((LedgerKeyClaimableBalance)decodedOperation.LedgerKey).BalanceId.ToLower());
+            ((LedgerKeyClaimableBalance)decodedOperation.LedgerKey).BalanceId);
     }
 
     [TestMethod]
@@ -805,9 +792,7 @@ public class OperationTest
         Assert.AreEqual(operation.From.AccountId, parsedOperation.From.AccountId);
     }
 
-
     [TestMethod]
-    [Obsolete]
     public void TestClawbackClaimableBalanceOperation()
     {
         // GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3
@@ -822,7 +807,7 @@ public class OperationTest
         Assert.IsNotNull(operation.SourceAccount);
         Assert.IsNotNull(parsedOperation.SourceAccount);
         Assert.AreEqual(operation.SourceAccount.AccountId, parsedOperation.SourceAccount.AccountId);
-        Assert.AreEqual(operation.BalanceIdInBytes.Length, parsedOperation.BalanceIdInBytes.Length);
+        Assert.AreEqual(operation.BalanceId.ToUpper(), parsedOperation.BalanceId.ToUpper());
     }
 
     [TestMethod]

--- a/StellarDotnetSdk.Tests/SorobanServerTest.cs
+++ b/StellarDotnetSdk.Tests/SorobanServerTest.cs
@@ -905,8 +905,8 @@ public class SorobanServerTest
         var ledgerKey = response.LedgerKeys[0] as LedgerKeyClaimableBalance;
         Assert.IsNotNull(ledgerEntry);
         Assert.IsNotNull(ledgerKey);
-        Assert.AreEqual("299a32106238f3b2d84d4142783fe320253bcda775d1bfb7accdb533021ddccf",
-            ledgerKey.BalanceId.ToLower());
+        Assert.AreEqual("BAACTGRSCBRDR45S3BGUCQTYH7RSAJJ3ZWTXLUN7W6WM3NJTAIO5ZT2U6I",
+            ledgerKey.BalanceId);
         Assert.AreEqual(457593U, ledgerEntry.LastModifiedLedgerSeq);
         Assert.AreEqual("native", ledgerEntry.Asset.Type);
         Assert.AreEqual(200000000L, ledgerEntry.Amount);

--- a/StellarDotnetSdk.Tests/Transactions/TransactionMetaTest.cs
+++ b/StellarDotnetSdk.Tests/Transactions/TransactionMetaTest.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using StellarDotnetSdk.Accounts;
 using StellarDotnetSdk.LedgerEntries;
+using StellarDotnetSdk.LedgerKeys;
 using StellarDotnetSdk.Soroban;
 using StellarDotnetSdk.Xdr;
 using ContractEvent = StellarDotnetSdk.Xdr.ContractEvent;
@@ -368,7 +369,8 @@ public class TransactionMetaTest
         Assert.IsNotNull(createdEntry);
         Assert.IsNull(createdEntry.ClaimableBalanceEntryExtensionV1);
         Assert.AreEqual(xdrCreatedEntry.Amount.InnerValue, createdEntry.Amount);
-        CollectionAssert.AreEqual(xdrCreatedEntry.BalanceID.V0.InnerValue, createdEntry.BalanceId);
+        Assert.AreEqual(ClaimableBalanceUtils.FromXdr(xdrCreatedEntry.BalanceID),
+            createdEntry.BalanceId);
         Assert.AreEqual(xdrCreatedEntry.Claimants.Length, createdEntry.Claimants.Length);
         for (var l = 0; l < createdEntry.Claimants.Length; l++)
         {

--- a/StellarDotnetSdk/ClaimableBalanceUtils.cs
+++ b/StellarDotnetSdk/ClaimableBalanceUtils.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using StellarDotnetSdk.Xdr;
+using ClaimableVersion = StellarDotnetSdk.Xdr.ClaimableBalanceIDType.ClaimableBalanceIDTypeEnum;
+
+namespace StellarDotnetSdk;
+
+public static class ClaimableBalanceUtils
+{
+    internal static ClaimableBalanceID ToXdr(string claimableBalanceId)
+    {
+        var decoded = StrKey.DecodeClaimableBalanceId(claimableBalanceId);
+        // The first byte is the version
+        var version = decoded[0];
+
+        // So, the raw ID should not contain the version byte
+        var rawId = decoded[1..];
+        return version switch
+        {
+            0 => new ClaimableBalanceID
+            {
+                Discriminant = ClaimableBalanceIDType.Create(
+                    ClaimableVersion.CLAIMABLE_BALANCE_ID_TYPE_V0),
+                V0 = new Hash(rawId),
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(version),
+                $"Claimable balance ID version {version} is not supported."),
+        };
+    }
+
+    /// <summary>
+    ///     Converts from a <see cref="Xdr.ClaimableBalanceID">Xdr.ClaimableBalanceID</see>
+    ///     to claimable balance ID (B...).
+    /// </summary>
+    /// <param name="xdr">An <see cref="Xdr.ClaimableBalanceID">Xdr.ClaimableBalanceID</see> object.</param>
+    /// <returns>A base32-encoded claimable balance ID (B...).</returns>
+    public static string FromXdr(ClaimableBalanceID xdr)
+    {
+        var version = xdr.Discriminant.InnerValue;
+        var rawId = version switch
+        {
+            ClaimableVersion.CLAIMABLE_BALANCE_ID_TYPE_V0 => xdr.V0.InnerValue,
+            _ => throw new ArgumentOutOfRangeException(nameof(version),
+                $"Claimable balance ID version {version} is not supported."),
+        };
+        // The actual ID contains the version as the first byte
+        byte[] fullId = [(byte)version, .. rawId];
+
+        return StrKey.EncodeClaimableBalanceId(fullId);
+    }
+
+    /// <summary>
+    ///     Converts a base32 encoded claimable balance ID (B...) to hex format (0000...).
+    ///     The hex ID can then be used in Horizon or RPC endpoints.
+    /// </summary>
+    /// <param name="base32Id">A base32-encoded claimable balance ID (B...).</param>
+    /// <returns>A hex-encoded claimable balance ID.</returns>
+    public static string ToHexString(string base32Id)
+    {
+        var xdr = ToXdr(base32Id);
+        return ToHexString(xdr);
+    }
+
+    /// <summary>
+    ///     Converts a hex-encoded claimable balance ID (0000...) to base32 format (B...).
+    /// </summary>
+    /// <param name="hex">A hex-encoded claimable balance ID (0000...).</param>
+    /// <returns>A base32-encoded claimable balance ID.</returns>
+    public static string ToBase32String(string hex)
+    {
+        var xdr = FromHexString(hex);
+        return FromXdr(xdr);
+    }
+
+    internal static string ToHexString(ClaimableBalanceID xdr)
+    {
+        var os = new XdrDataOutputStream();
+        ClaimableBalanceID.Encode(os, xdr);
+        return Convert.ToHexString(os.ToArray());
+    }
+
+    internal static ClaimableBalanceID FromHexString(string hex)
+    {
+        try
+        {
+            var inputStream = new XdrDataInputStream(Convert.FromHexString(hex));
+            return ClaimableBalanceID.Decode(inputStream);
+        }
+        catch
+        {
+            throw new ArgumentException($"Invalid claimable balance ID {hex}.");
+        }
+    }
+}

--- a/StellarDotnetSdk/LedgerEntries/LedgerEntryClaimableBalance.cs
+++ b/StellarDotnetSdk/LedgerEntries/LedgerEntryClaimableBalance.cs
@@ -8,16 +8,24 @@ namespace StellarDotnetSdk.LedgerEntries;
 
 public class LedgerEntryClaimableBalance : LedgerEntry
 {
-    private LedgerEntryClaimableBalance(byte[] balanceId, claimant_Claimant[] claimants, Assets_Asset asset,
-        long amount)
+    private LedgerEntryClaimableBalance(
+        string balanceId,
+        claimant_Claimant[] claimants,
+        Assets_Asset asset,
+        long amount
+    )
     {
+        if (!StrKey.IsValidClaimableBalanceId(balanceId))
+        {
+            throw new ArgumentException($"Invalid claimable balance ID {balanceId}.");
+        }
         BalanceId = balanceId;
         Claimants = claimants;
         Asset = asset;
         Amount = amount;
     }
 
-    public byte[] BalanceId { get; }
+    public string BalanceId { get; }
     public claimant_Claimant[] Claimants { get; }
     public Assets_Asset Asset { get; }
     public long Amount { get; }
@@ -40,18 +48,18 @@ public class LedgerEntryClaimableBalance : LedgerEntry
         return FromXdr(xdrLedgerEntryData.ClaimableBalance);
     }
 
-    private static LedgerEntryClaimableBalance FromXdr(ClaimableBalanceEntry xdrClaimableBalanceEntry)
+    private static LedgerEntryClaimableBalance FromXdr(ClaimableBalanceEntry xdrEntry)
     {
         var ledgerEntryClaimableBalance = new LedgerEntryClaimableBalance(
-            xdrClaimableBalanceEntry.BalanceID.V0.InnerValue,
-            xdrClaimableBalanceEntry.Claimants.Select(claimant_Claimant.FromXdr).ToArray(),
-            Assets_Asset.FromXdr(xdrClaimableBalanceEntry.Asset),
-            xdrClaimableBalanceEntry.Amount.InnerValue);
+            ClaimableBalanceUtils.FromXdr(xdrEntry.BalanceID),
+            xdrEntry.Claimants.Select(claimant_Claimant.FromXdr).ToArray(),
+            Assets_Asset.FromXdr(xdrEntry.Asset),
+            xdrEntry.Amount.InnerValue);
 
-        if (xdrClaimableBalanceEntry.Ext.Discriminant == 1)
+        if (xdrEntry.Ext.Discriminant == 1)
         {
             ledgerEntryClaimableBalance.ClaimableBalanceEntryExtensionV1 =
-                ClaimableBalanceEntryExtensionV1.FromXdr(xdrClaimableBalanceEntry.Ext.V1);
+                ClaimableBalanceEntryExtensionV1.FromXdr(xdrEntry.Ext.V1);
         }
 
         return ledgerEntryClaimableBalance;

--- a/StellarDotnetSdk/LedgerKeys/LedgerKey.cs
+++ b/StellarDotnetSdk/LedgerKeys/LedgerKey.cs
@@ -17,19 +17,11 @@ public abstract class LedgerKey
         return new LedgerKeyAccount(account);
     }
 
-    public static LedgerKey ClaimableBalance(byte[] balanceId)
+    /// <summary>Constructs a new <c>LedgerKeyClaimableBalance</c> from a claimable balance ID (B...).</summary>
+    /// <param name="balanceId">A base32-encoded claimable balance ID (B...).</param>
+    public static LedgerKey ClaimableBalance(string balanceId)
     {
         return new LedgerKeyClaimableBalance(balanceId);
-    }
-
-    /// <summary>Constructs a new <c>LedgerKeyClaimableBalance</c> from the given hex-encoded claimable balance ID.</summary>
-    /// <param name="balanceIdHexString">
-    ///     Hex-encoded ID of the claimable balance entry.
-    ///     For example: <c>d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780</c>.
-    /// </param>
-    public static LedgerKey ClaimableBalance(string balanceIdHexString)
-    {
-        return new LedgerKeyClaimableBalance(balanceIdHexString);
     }
 
     public static LedgerKey Data(KeyPair account, string dataName)

--- a/StellarDotnetSdk/LedgerKeys/LedgerKeyClaimableBalance.cs
+++ b/StellarDotnetSdk/LedgerKeys/LedgerKeyClaimableBalance.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using StellarDotnetSdk.Xdr;
 
 namespace StellarDotnetSdk.LedgerKeys;
@@ -6,32 +7,16 @@ namespace StellarDotnetSdk.LedgerKeys;
 public class LedgerKeyClaimableBalance : LedgerKey
 {
     /// <summary>
-    ///     Constructs a <c>LedgerKeyClaimableBalance</c> object from a 32-byte array.
+    ///     Constructs a <c>LedgerKeyClaimableBalance</c> from a claimable balance ID (B...).
     /// </summary>
-    /// <param name="balanceIdByteArray">Byte array representation of the claimable balance entry.</param>
-    public LedgerKeyClaimableBalance(byte[] balanceIdByteArray)
+    /// <param name="balanceId">A base32-encoded claimable balance ID (B...).</param>
+    public LedgerKeyClaimableBalance(string balanceId)
     {
-        if (balanceIdByteArray.Length != 32)
+        if (!StrKey.IsValidClaimableBalanceId(balanceId))
         {
-            throw new ArgumentException("Claimable balance ID byte array must have exactly 32 bytes.", nameof(balanceIdByteArray));
+            throw new ArgumentException($"Invalid claimable balance ID {balanceId}.");
         }
-        BalanceId = Convert.ToHexString(balanceIdByteArray);
-    }
-
-    /// <summary>
-    ///     Constructs a <c>LedgerKeyClaimableBalance</c> from given hex-encoded claimable balance ID.
-    /// </summary>
-    /// <param name="balanceIdHexString">
-    ///     Hex-encoded ID of the claimable balance entry.
-    ///     For example: <c>d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780</c>.
-    /// </param>
-    public LedgerKeyClaimableBalance(string balanceIdHexString)
-    {
-        if (balanceIdHexString.Length > 64)
-        {
-            throw new ArgumentException("Claimable balance ID cannot exceed 64 characters.", nameof(balanceIdHexString));
-        }
-        BalanceId = balanceIdHexString;
+        BalanceId = balanceId;
     }
 
     public string BalanceId { get; }
@@ -44,21 +29,15 @@ public class LedgerKeyClaimableBalance : LedgerKey
                 new LedgerEntryType { InnerValue = LedgerEntryType.LedgerEntryTypeEnum.CLAIMABLE_BALANCE },
             ClaimableBalance = new Xdr.LedgerKey.LedgerKeyClaimableBalance
             {
-                BalanceID = new ClaimableBalanceID
-                {
-                    Discriminant = new ClaimableBalanceIDType
-                    {
-                        InnerValue = ClaimableBalanceIDType.ClaimableBalanceIDTypeEnum.CLAIMABLE_BALANCE_ID_TYPE_V0,
-                    },
-                    V0 = new Hash(Convert.FromHexString(BalanceId)),
-                },
+                BalanceID = ClaimableBalanceUtils.ToXdr(BalanceId),
             },
         };
     }
 
     public static LedgerKeyClaimableBalance FromXdr(Xdr.LedgerKey.LedgerKeyClaimableBalance xdr)
     {
-        var balanceId = xdr.BalanceID.V0.InnerValue;
-        return new LedgerKeyClaimableBalance(balanceId);
+        return new LedgerKeyClaimableBalance(
+            ClaimableBalanceUtils.FromXdr(xdr.BalanceID)
+        );
     }
 }

--- a/StellarDotnetSdk/Operations/ClaimClaimableBalanceOperation.cs
+++ b/StellarDotnetSdk/Operations/ClaimClaimableBalanceOperation.cs
@@ -18,40 +18,22 @@ public class ClaimClaimableBalanceOperation : Operation
     /// <summary>
     ///     Constructs a new <c>ClaimClaimableBalanceOperation</c>.
     /// </summary>
-    /// <param name="balanceIdHexString">The hex-encoded ID of the ClaimableBalanceEntry to be claimed.</param>
+    /// <param name="balanceId">The hex-encoded ID (0000...) of the ClaimableBalanceEntry to be claimed.</param>
     /// <param name="sourceAccount">(Optional) Source account of the operation.</param>
-    public ClaimClaimableBalanceOperation(string balanceIdHexString, IAccountId? sourceAccount = null)
-        : this(Util.HexToBytes(balanceIdHexString), sourceAccount)
+    public ClaimClaimableBalanceOperation(string balanceId, IAccountId? sourceAccount = null)
+        : base(sourceAccount)
     {
-    }
-
-    private ClaimClaimableBalanceOperation(byte[] balanceId, IAccountId? sourceAccount = null) : base(sourceAccount)
-    {
-        // Backwards compat - was previously expecting no type to be set, set CLAIMABLE_BALANCE_ID_TYPE_V0 to match previous behaviour.
-        if (balanceId.Length == 32)
+        if (!StrKey.IsValidClaimableBalanceId(ClaimableBalanceUtils.ToBase32String(balanceId)))
         {
-            var expanded = new byte[36];
-            Array.Copy(balanceId, 0, expanded, 4, 32);
-            balanceId = expanded;
+            throw new ArgumentException($"Invalid claimable balance ID {balanceId}");
         }
-
-        if (balanceId.Length != 36)
-        {
-            throw new ArgumentException("Must be 36 bytes long", nameof(balanceId));
-        }
-
-        BalanceIdInBytes = balanceId;
+        BalanceId = balanceId;
     }
 
     /// <summary>
-    ///     Hex-encoded ID of the ClaimableBalanceEntry to be claimed.
+    ///     Hex-encoded ID (0000...) of the ClaimableBalanceEntry to be claimed.
     /// </summary>
-    public string BalanceId => Util.BytesToHex(BalanceIdInBytes);
-
-    /// <summary>
-    ///     ID of the ClaimableBalanceEntry to be claimed as a byte array.
-    /// </summary>
-    public byte[] BalanceIdInBytes { get; }
+    public string BalanceId { get; }
 
     public override Xdr.Operation.OperationBody ToOperationBody()
     {
@@ -60,7 +42,7 @@ public class ClaimClaimableBalanceOperation : Operation
             Discriminant = OperationType.Create(OperationType.OperationTypeEnum.CLAIM_CLAIMABLE_BALANCE),
             ClaimClaimableBalanceOp = new ClaimClaimableBalanceOp
             {
-                BalanceID = ClaimableBalanceID.Decode(new XdrDataInputStream(BalanceIdInBytes)),
+                BalanceID = ClaimableBalanceUtils.FromHexString(BalanceId),
             },
         };
     }

--- a/StellarDotnetSdk/Operations/ClawbackClaimableBalanceOperation.cs
+++ b/StellarDotnetSdk/Operations/ClawbackClaimableBalanceOperation.cs
@@ -17,36 +17,22 @@ public class ClawbackClaimableBalanceOperation : Operation
     /// <summary>
     ///     Constructs a new <c>ClawbackClaimableBalanceOperation</c>.
     /// </summary>
-    /// <param name="balanceIdInBytes">The hex-encoded ID of the ClaimableBalanceEntry to be clawed back.</param>
+    /// <param name="balanceId">The hex-encoded ID (0000...) of the ClaimableBalanceEntry to be clawed back.</param>
     /// <param name="sourceAccount">(Optional) Source account of the operation.</param>
-    public ClawbackClaimableBalanceOperation(string balanceId, IAccountId? sourceAccount = null) : base(sourceAccount)
+    public ClawbackClaimableBalanceOperation(string balanceId, IAccountId? sourceAccount = null)
+        : base(sourceAccount)
     {
-        var balanceIdInBytes = Util.HexToBytes(balanceId);
-        // Backwards compatibility - was previously expecting no type to be set.
-        if (balanceIdInBytes.Length == 32)
+        if (!StrKey.IsValidClaimableBalanceId(ClaimableBalanceUtils.ToBase32String(balanceId)))
         {
-            var expanded = new byte[36];
-            Array.Copy(balanceIdInBytes, 0, expanded, 4, 32);
-            balanceIdInBytes = expanded;
+            throw new ArgumentException($"Invalid claimable balance ID {balanceId}");
         }
-
-        if (balanceIdInBytes.Length != 36)
-        {
-            throw new ArgumentException("Must be 36 bytes long", nameof(balanceIdInBytes));
-        }
-
-        BalanceIdInBytes = balanceIdInBytes;
+        BalanceId = balanceId;
     }
 
     /// <summary>
-    ///     Hex-encoded ID of the ClaimableBalanceEntry to be clawed back.
+    ///     Hex-encoded ID (0000...) of the ClaimableBalanceEntry to be clawed back.
     /// </summary>
-    public string BalanceId => Util.BytesToHex(BalanceIdInBytes);
-
-    /// <summary>
-    ///     ID of the ClaimableBalanceEntry to be clawed back as a byte array.
-    /// </summary>
-    public byte[] BalanceIdInBytes { get; }
+    public string BalanceId { get; }
 
     public override Xdr.Operation.OperationBody ToOperationBody()
     {
@@ -55,7 +41,7 @@ public class ClawbackClaimableBalanceOperation : Operation
             Discriminant = OperationType.Create(OperationType.OperationTypeEnum.CLAWBACK_CLAIMABLE_BALANCE),
             ClawbackClaimableBalanceOp = new ClawbackClaimableBalanceOp
             {
-                BalanceID = ClaimableBalanceID.Decode(new XdrDataInputStream(BalanceIdInBytes)),
+                BalanceID = ClaimableBalanceUtils.FromHexString(BalanceId),
             },
         };
     }

--- a/StellarDotnetSdk/Operations/Operation.cs
+++ b/StellarDotnetSdk/Operations/Operation.cs
@@ -101,7 +101,7 @@ public abstract class Operation
             OperationType.OperationTypeEnum.CREATE_CLAIMABLE_BALANCE => CreateClaimableBalanceOperation.FromXdr(
                 body.CreateClaimableBalanceOp),
             OperationType.OperationTypeEnum.CLAIM_CLAIMABLE_BALANCE => new ClaimClaimableBalanceOperation(
-                Util.BytesToHex(body.ClaimClaimableBalanceOp.BalanceID.V0.InnerValue)),
+                ClaimableBalanceUtils.ToHexString(body.ClaimClaimableBalanceOp.BalanceID)),
             OperationType.OperationTypeEnum.BEGIN_SPONSORING_FUTURE_RESERVES =>
                 new BeginSponsoringFutureReservesOperation(
                     KeyPair.FromXdrPublicKey(body.BeginSponsoringFutureReservesOp.SponsoredID.InnerValue)),
@@ -121,7 +121,7 @@ public abstract class Operation
             OperationType.OperationTypeEnum.CLAWBACK => ClawbackOperation.FromXdr(body.ClawbackOp),
             OperationType.OperationTypeEnum.CLAWBACK_CLAIMABLE_BALANCE =>
                 new ClawbackClaimableBalanceOperation(
-                    Util.BytesToHex(body.ClawbackClaimableBalanceOp.BalanceID.V0.InnerValue)),
+                    ClaimableBalanceUtils.ToHexString(body.ClawbackClaimableBalanceOp.BalanceID)),
             OperationType.OperationTypeEnum.SET_TRUST_LINE_FLAGS => SetTrustlineFlagsOperation.FromXdr(
                 body.SetTrustLineFlagsOp),
             OperationType.OperationTypeEnum.LIQUIDITY_POOL_DEPOSIT => LiquidityPoolDepositOperation.FromXdr(

--- a/StellarDotnetSdk/Operations/RevokeLedgerEntrySponsorshipOperation.cs
+++ b/StellarDotnetSdk/Operations/RevokeLedgerEntrySponsorshipOperation.cs
@@ -49,17 +49,18 @@ public class RevokeLedgerEntrySponsorshipOperation : Operation
     /// <summary>
     ///     Constructs new revoke balance entry sponsorship operation.
     /// </summary>
-    /// <param name="balanceIdHexString">
-    ///     Hex-encoded ID of the claimable balance entry to be revoked.
-    ///     For example: <c>d1d73327fc560cc09f54a11c7a64180611e1f480f3bf60117e41d19d9593b780</c>.
+    /// <param name="balanceId">
+    ///     Hex-encoded ID (0000...) of the claimable balance entry to be revoked.
     /// </param>
     public static RevokeLedgerEntrySponsorshipOperation ForClaimableBalance(
-        string balanceIdHexString,
+        string balanceId,
         IAccountId? sourceAccount = null)
     {
+        var base32Id = ClaimableBalanceUtils.ToBase32String(balanceId);
         return new RevokeLedgerEntrySponsorshipOperation(
-            new LedgerKeyClaimableBalance(balanceIdHexString),
-            sourceAccount);
+            new LedgerKeyClaimableBalance(base32Id),
+            sourceAccount
+        );
     }
 
     /// <summary>

--- a/StellarDotnetSdk/Requests/OperationsRequestBuilder.cs
+++ b/StellarDotnetSdk/Requests/OperationsRequestBuilder.cs
@@ -72,19 +72,19 @@ public class OperationsRequestBuilder : RequestBuilderStreamable<OperationsReque
     ///     Builds request to GET /claimable_balances/{claimable_balance_id}/operations
     ///     See: https://www.stellar.org/developers/horizon/reference/operations-for-claimable-balance.html
     /// </summary>
-    /// <param name="claimableBalance">Claimable Balance for which to get operations</param>
+    /// <param name="claimableBalanceId">Base32-encoded claimable balance ID for which to get operations.</param>
     /// <returns>
     ///     <see cref="OperationsRequestBuilder" />
     /// </returns>
     /// <exception cref="HttpRequestException"></exception>
-    public OperationsRequestBuilder ForClaimableBalance(string claimableBalance)
+    public OperationsRequestBuilder ForClaimableBalance(string claimableBalanceId)
     {
-        if (string.IsNullOrWhiteSpace(claimableBalance))
+        if (string.IsNullOrWhiteSpace(claimableBalanceId))
         {
-            throw new ArgumentNullException(nameof(claimableBalance), "claimableBalance cannot be null");
+            throw new ArgumentNullException(nameof(claimableBalanceId), "claimableBalance cannot be null");
         }
 
-        SetSegments("claimable_balances", claimableBalance, "operations");
+        SetSegments("claimable_balances", claimableBalanceId, "operations");
 
         return this;
     }

--- a/StellarDotnetSdk/Responses/Results/CreateClaimableBalanceResult.cs
+++ b/StellarDotnetSdk/Responses/Results/CreateClaimableBalanceResult.cs
@@ -18,7 +18,7 @@ public class CreateClaimableBalanceResult : OperationResult
             ResultCodeEnum.CREATE_CLAIMABLE_BALANCE_NO_TRUST
                 => new CreateClaimableBalanceNoTrust(),
             ResultCodeEnum.CREATE_CLAIMABLE_BALANCE_SUCCESS
-                => new CreateClaimableBalanceSuccess(result.BalanceID.V0.InnerValue),
+                => new CreateClaimableBalanceSuccess(ClaimableBalanceUtils.ToHexString(result.BalanceID)),
             ResultCodeEnum.CREATE_CLAIMABLE_BALANCE_UNDERFUNDED
                 => new CreateClaimableBalanceUnderfunded(),
             _ => throw new ArgumentOutOfRangeException(nameof(result), "Unknown CreateClaimableBalanceResult type."),
@@ -28,12 +28,24 @@ public class CreateClaimableBalanceResult : OperationResult
 
 public class CreateClaimableBalanceSuccess : CreateClaimableBalanceResult
 {
-    public CreateClaimableBalanceSuccess(byte[] balanceId)
+    /// <summary>
+    ///     Constructs a new <c>CreateClaimableBalanceSuccess</c> result.
+    /// </summary>
+    /// <param name="balanceId">A hex-encoded claimable balance ID (0000...).</param>
+    public CreateClaimableBalanceSuccess(string balanceId)
     {
-        BalanceId = Convert.ToHexString(balanceId);
+        if (!StrKey.IsValidClaimableBalanceId(ClaimableBalanceUtils.ToBase32String(balanceId)))
+        {
+            throw new ArgumentException($"Invalid claimable balance ID {balanceId}");
+        }
+        BalanceId = balanceId;
     }
 
     public override bool IsSuccess => true;
+
+    /// <summary>
+    ///     Hex-encoded claimable balance ID (0000...).
+    /// </summary>
     public string BalanceId { get; }
 }
 

--- a/StellarDotnetSdk/Soroban/ScAddress.cs
+++ b/StellarDotnetSdk/Soroban/ScAddress.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Linq;
 using StellarDotnetSdk.Accounts;
 using StellarDotnetSdk.Xdr;
 using SCAddressTypeEnum = StellarDotnetSdk.Xdr.SCAddressType.SCAddressTypeEnum;
-using ClaimableBalanceIDTypeEnum = StellarDotnetSdk.Xdr.ClaimableBalanceIDType.ClaimableBalanceIDTypeEnum;
 
 namespace StellarDotnetSdk.Soroban;
 
@@ -100,7 +98,7 @@ public class ScAccountId : ScAddress
 public class ScClaimableBalanceId : ScAddress
 {
     /// <summary>
-    ///     Creates an ScClaimableBalanceId instance from a claimable balance ID (B...).
+    ///     Creates an <c>ScClaimableBalanceId</c> instance from a claimable balance ID (B...).
     /// </summary>
     /// <param name="claimableBalanceId">A base32-encoded claimable balance ID (B...).</param>
     public ScClaimableBalanceId(string claimableBalanceId)
@@ -117,46 +115,17 @@ public class ScClaimableBalanceId : ScAddress
 
     public static ScClaimableBalanceId FromXdr(SCAddress xdr)
     {
-        var version = (byte)xdr.ClaimableBalanceId.Discriminant.InnerValue;
-        // The actual ID contains the version as the first byte
-        var id = xdr.ClaimableBalanceId.V0.InnerValue.Prepend(version).ToArray();
-        if (xdr.ClaimableBalanceId.Discriminant.InnerValue !=
-            ClaimableBalanceIDTypeEnum.CLAIMABLE_BALANCE_ID_TYPE_V0)
-        {
-            throw new ArgumentException("Only CLAIMABLE_BALANCE_ID_TYPE_V0 is supported.");
-        }
         return new ScClaimableBalanceId(
-            StrKey.EncodeClaimableBalanceId(id)
+            ClaimableBalanceUtils.FromXdr(xdr.ClaimableBalanceId)
         );
     }
 
     public override SCAddress ToXdr()
     {
-        var decoded = StrKey.DecodeClaimableBalanceId(InnerValue);
-        // The first byte should be the claimable version
-        var version = decoded[0];
-
-        // So, the actual ID should not contain the first byte
-        var id = decoded[1..];
-
         return new SCAddress
         {
             Discriminant = SCAddressType.Create(SCAddressTypeEnum.SC_ADDRESS_TYPE_CLAIMABLE_BALANCE),
-            ClaimableBalanceId = CreateXdrClaimableBalanceId(version, id),
-        };
-    }
-
-    private static ClaimableBalanceID CreateXdrClaimableBalanceId(byte version, byte[] id)
-    {
-        return version switch
-        {
-            0 => new ClaimableBalanceID
-            {
-                Discriminant = ClaimableBalanceIDType.Create(
-                    ClaimableBalanceIDTypeEnum.CLAIMABLE_BALANCE_ID_TYPE_V0),
-                V0 = new Hash(id),
-            },
-            _ => throw new NotSupportedException($"Claimable balance ID version {version} is not supported."),
+            ClaimableBalanceId = ClaimableBalanceUtils.ToXdr(InnerValue),
         };
     }
 }

--- a/StellarDotnetSdk/StrKey.cs
+++ b/StellarDotnetSdk/StrKey.cs
@@ -8,7 +8,7 @@ namespace StellarDotnetSdk;
 
 using MuxedAccount = xdrSDK.MuxedAccount;
 
-public class StrKey
+public static class StrKey
 {
     public enum VersionByte : byte
     {


### PR DESCRIPTION
## Types of changes
- Fixed compatibility issues with claimable balance ID arguments across all ID versions
- Standardized operations to consistently use hex-encoded claimable balance IDs, aligning with Horizon/RPC endpoint formats
- Added utility functions for seamless conversion between base32-encoded and hex-encoded claimable balance ID formats

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
