### PR TITLE
fix: type inconsistencies for date time properties

### DIFF
--- a/StellarDotnetSdk.Tests/Requests/OffersRequestBuilderTest.cs
+++ b/StellarDotnetSdk.Tests/Requests/OffersRequestBuilderTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using StellarDotnetSdk.Assets;
 using StellarDotnetSdk.Requests;
@@ -128,7 +129,7 @@ public class OffersRequestBuilderTest
         Assert.AreEqual(new Price(1, 2), offer.PriceRatio);
         Assert.AreEqual("0.5000000", offer.Price);
         Assert.AreEqual(380, offer.LastModifiedLedger);
-        Assert.AreEqual("2024-12-10T17:50:08Z", offer.LastModifiedTime);
+        Assert.AreEqual(new DateTimeOffset(2024, 12, 10, 17, 50, 8, TimeSpan.Zero), offer.LastModifiedTime);
     }
 
     private async Task<Server> CreateServer()

--- a/StellarDotnetSdk.Tests/Responses/ClaimableBalanceDeserializerTest.cs
+++ b/StellarDotnetSdk.Tests/Responses/ClaimableBalanceDeserializerTest.cs
@@ -45,7 +45,7 @@ public class ClaimableBalanceDeserializerTest
         Assert.AreEqual("16.6666667", claimableBalance.Amount);
         Assert.AreEqual("GDERZDEWIYBPWFQLG7GV5BWC4BXSD5KCQ734D42P72IG5COAYIFB2DTB", claimableBalance.Sponsor);
         Assert.AreEqual(65909, claimableBalance.LastModifiedLedger);
-        Assert.AreEqual(new DateTimeOffset(2025, 8, 18, 13, 02, 39, TimeSpan.Zero), claimableBalance.LastModifiedTime);
+        Assert.AreEqual(new DateTimeOffset(2025, 8, 18, 13, 2, 39, TimeSpan.Zero), claimableBalance.LastModifiedTime);
         Assert.AreEqual("65909-000000009832889118c5fcf2cfb3c082e079520c516300b5276b839cb934cf88ebc9244a",
             claimableBalance.PagingToken);
 

--- a/StellarDotnetSdk.Tests/Responses/LedgerDeserializeTest.cs
+++ b/StellarDotnetSdk.Tests/Responses/LedgerDeserializeTest.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Text.Json;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using StellarDotnetSdk.Converters;
@@ -41,7 +42,7 @@ public class LedgerDeserializeTest
         Assert.AreEqual(0, ledger.SuccessfulTransactionCount);
         Assert.AreEqual(0, ledger.FailedTransactionCount);
         Assert.AreEqual(0, ledger.OperationCount);
-        Assert.AreEqual("2025-12-01T06:13:55Z", ledger.ClosedAt);
+        Assert.AreEqual(new DateTimeOffset(2025, 12, 1, 6, 13, 55, TimeSpan.Zero), ledger.ClosedAt);
         Assert.AreEqual("100000000000.0000000", ledger.TotalCoins);
         Assert.AreEqual("110238.5552711", ledger.FeePool);
         Assert.AreEqual(100L, ledger.BaseFeeInStroops);

--- a/StellarDotnetSdk.Tests/Responses/OfferPageDeserializerTest.cs
+++ b/StellarDotnetSdk.Tests/Responses/OfferPageDeserializerTest.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Text.Json;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -55,7 +56,8 @@ public class OfferPageDeserializerTest
             .Should().Be(10);
 
         Assert.AreEqual(offerResponsePage.Records[0].LastModifiedLedger, 22200794);
-        Assert.AreEqual(offerResponsePage.Records[0].LastModifiedTime, "2019-01-28T12:30:38Z");
+        Assert.AreEqual(offerResponsePage.Records[0].LastModifiedTime,
+            new DateTimeOffset(2019, 1, 28, 12, 30, 38, TimeSpan.Zero));
 
         Assert.AreEqual(offerResponsePage.Links.Next.Href,
             "https://horizon-testnet.stellar.org/accounts/GA2IYMIZSAMDD6QQTTSIEL73H2BKDJQTA7ENDEEAHJ3LMVF7OYIZPXQD/offers?order=asc&limit=10&cursor=241");

--- a/StellarDotnetSdk.Tests/Responses/TradesPageDeserializerTest.cs
+++ b/StellarDotnetSdk.Tests/Responses/TradesPageDeserializerTest.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Text.Json;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -44,7 +45,8 @@ public class TradesPageDeserializerTest
         Assert.AreEqual(tradesPage.Records[0].Id, "68836918321750017-0");
         Assert.AreEqual(tradesPage.Records[0].PagingToken, "68836918321750017-0");
 
-        Assert.AreEqual(tradesPage.Records[0].LedgerCloseTime, "2018-02-02T00:20:10Z");
+        Assert.AreEqual(tradesPage.Records[0].LedgerCloseTime,
+            new DateTimeOffset(2018, 2, 2, 0, 20, 10, TimeSpan.Zero));
         Assert.AreEqual(tradesPage.Records[0].OfferId, "695254");
         Assert.AreEqual(tradesPage.Records[0].BaseOfferId, "10");
         Assert.AreEqual(tradesPage.Records[0].CounterOfferId, "11");

--- a/StellarDotnetSdk.Tests/SorobanServerTest.cs
+++ b/StellarDotnetSdk.Tests/SorobanServerTest.cs
@@ -490,7 +490,7 @@ public class SorobanServerTest
         Assert.IsNotNull(event1);
         Assert.AreEqual("contract", event1.Type);
         Assert.AreEqual(912707, event1.Ledger);
-        Assert.AreEqual("2024-08-06T10:09:22Z", event1.LedgerClosedAt);
+        Assert.AreEqual(new DateTimeOffset(2024, 8, 6, 10, 9, 22, TimeSpan.Zero), event1.LedgerClosedAt);
         Assert.AreEqual("CASCLAHV7E7H3BOGQIW5HIC3H6WVDOTOQRTRMXYSTKJHXOORP3DNATY2", event1.ContractId);
         Assert.AreEqual("0003920046715838464-0000000001", event1.Id);
         Assert.AreEqual(2, event1.Topics.Length);
@@ -508,7 +508,7 @@ public class SorobanServerTest
         Assert.IsNotNull(event2);
         Assert.AreEqual("contract", event2.Type);
         Assert.AreEqual(912723, event2.Ledger);
-        Assert.AreEqual("2024-08-06T10:10:47Z", event2.LedgerClosedAt);
+        Assert.AreEqual(new DateTimeOffset(2024, 8, 6, 10, 10, 47, TimeSpan.Zero), event2.LedgerClosedAt);
         Assert.AreEqual("CDTJALOV4KLSPEMNFHKYSG4WOTN7FCN4A2JOKRPVCQYEHLUEH2YUJF5R", event2.ContractId);
         Assert.AreEqual("0003920115435319296-0000000001", event2.Id);
         Assert.AreEqual(3, event2.Topics.Length);
@@ -525,7 +525,7 @@ public class SorobanServerTest
         Assert.IsNotNull(event3);
         Assert.AreEqual("contract", event3.Type);
         Assert.AreEqual(912725, event3.Ledger);
-        Assert.AreEqual("2024-08-06T10:10:58Z", event3.LedgerClosedAt);
+        Assert.AreEqual(new DateTimeOffset(2024, 8, 6, 10, 10, 58, TimeSpan.Zero), event3.LedgerClosedAt);
         Assert.AreEqual("CDYTK2FLRHT3KJ6RVAAABI4A7Y2XERCWN3FT5II7FHONDKPQVEAZ33YI", event3.ContractId);
         Assert.AreEqual("0003920124025257984-0000000001", event3.Id);
         Assert.AreEqual(3, event3.Topics.Length);
@@ -542,7 +542,7 @@ public class SorobanServerTest
         Assert.IsNotNull(event4);
         Assert.AreEqual("contract", event4.Type);
         Assert.AreEqual(913037, event4.Ledger);
-        Assert.AreEqual("2024-08-06T10:38:23Z", event4.LedgerClosedAt);
+        Assert.AreEqual(new DateTimeOffset(2024, 8, 6, 10, 38, 23, TimeSpan.Zero), event4.LedgerClosedAt);
         Assert.AreEqual("CDV6IIE2DFFGB3GKAG7YYSKBO4PFDAZ76GRHXKSOBBIG64NNHMMRCRXH", event4.ContractId);
         Assert.AreEqual("0003921464055050240-0000000001", event4.Id);
         Assert.AreEqual(3, event4.Topics.Length);

--- a/StellarDotnetSdk/Responses/Effects/EffectResponse.cs
+++ b/StellarDotnetSdk/Responses/Effects/EffectResponse.cs
@@ -37,7 +37,7 @@ public abstract class EffectResponse : Response, IPagingToken
     public EffectsResponseLinks Links { get; init; }
 
     [JsonPropertyName("created_at")]
-    public DateTime CreatedAt { get; init; }
+    public DateTimeOffset CreatedAt { get; init; }
 
     [JsonPropertyName("paging_token")]
     public string PagingToken { get; init; }

--- a/StellarDotnetSdk/Responses/LedgerResponse.cs
+++ b/StellarDotnetSdk/Responses/LedgerResponse.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System;
+using System.Text.Json.Serialization;
 using StellarDotnetSdk.Responses.Effects;
 using StellarDotnetSdk.Responses.Operations;
 
@@ -54,10 +55,10 @@ public sealed class LedgerResponse : Response, IPagingToken
     public required int OperationCount { get; init; }
 
     /// <summary>
-    ///     An ISO 8601 formatted string of when this ledger was closed.
+    ///     The time when this ledger was closed.
     /// </summary>
     [JsonPropertyName("closed_at")]
-    public required string ClosedAt { get; init; }
+    public required DateTimeOffset ClosedAt { get; init; }
 
     /// <summary>
     ///     The total number of lumens in circulation.

--- a/StellarDotnetSdk/Responses/OfferResponse.cs
+++ b/StellarDotnetSdk/Responses/OfferResponse.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System;
+using System.Text.Json.Serialization;
 using StellarDotnetSdk.Assets;
 using StellarDotnetSdk.Converters;
 
@@ -42,7 +43,7 @@ public class OfferResponse : Response, IPagingToken
     public int LastModifiedLedger { get; init; }
 
     [JsonPropertyName("last_modified_time")]
-    public string LastModifiedTime { get; init; }
+    public DateTimeOffset? LastModifiedTime { get; init; }
 
     [JsonPropertyName("_links")]
     public OfferResponseLinks Links { get; init; }

--- a/StellarDotnetSdk/Responses/Operations/OperationResponse.cs
+++ b/StellarDotnetSdk/Responses/Operations/OperationResponse.cs
@@ -53,9 +53,10 @@ public abstract class OperationResponse : Response, IPagingToken
     public virtual int TypeId { get; }
 
     /// <summary>
+    ///     The time this operation was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public DateTime CreatedAt { get; init; }
+    public DateTimeOffset CreatedAt { get; init; }
 
     /// <summary>
     ///     Returns transaction hash of transaction this operation belongs to.

--- a/StellarDotnetSdk/Responses/SorobanRpc/GetEventsResponse.cs
+++ b/StellarDotnetSdk/Responses/SorobanRpc/GetEventsResponse.cs
@@ -61,11 +61,10 @@ public class GetEventsResponse
         public long Ledger { get; init; }
 
         /// <summary>
-        ///     ISO-8601 timestamp of the ledger closing time.
-        ///     See https://www.iso.org/iso-8601-date-and-time-format.html.
+        ///     The time when the ledger was closed.
         /// </summary>
         [JsonPropertyName("ledgerClosedAt")]
-        public string LedgerClosedAt { get; init; }
+        public DateTimeOffset LedgerClosedAt { get; init; }
 
         /// <summary>
         ///     A list containing the topics, each is a base-64 encoded XDR string of an <see cref="Xdr.SCVal">xdr.SCVal</see>

--- a/StellarDotnetSdk/Responses/TradeResponse.cs
+++ b/StellarDotnetSdk/Responses/TradeResponse.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System;
+using System.Text.Json.Serialization;
 using StellarDotnetSdk.Assets;
 using StellarDotnetSdk.LiquidityPool;
 using StellarDotnetSdk.Responses.Operations;
@@ -15,7 +16,7 @@ public class TradeResponse : Response, IPagingToken
     public string Id { get; init; }
 
     [JsonPropertyName("ledger_close_time")]
-    public string LedgerCloseTime { get; init; }
+    public DateTimeOffset LedgerCloseTime { get; init; }
 
     [JsonPropertyName("offer_id")]
     public string OfferId { get; init; }

--- a/StellarDotnetSdk/Responses/TransactionResponse.cs
+++ b/StellarDotnetSdk/Responses/TransactionResponse.cs
@@ -18,7 +18,7 @@ public class TransactionResponse : Response, IPagingToken
     public long Ledger { get; init; }
 
     [JsonPropertyName("created_at")]
-    public DateTime CreatedAt { get; init; }
+    public DateTimeOffset CreatedAt { get; init; }
 
     [JsonPropertyName("source_account")]
     public string SourceAccount { get; init; }


### PR DESCRIPTION
## Types of changes
- Fixes #114

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces date-time string fields with DateTimeOffset across response models (and adds `ClaimableBalanceResponse.last_modified_time`), updating tests accordingly.
> 
> - **Responses**:
>   - Convert date-time strings to `DateTimeOffset` in:
>     - `LedgerResponse.closed_at`
>     - `TransactionResponse.created_at`
>     - `OperationResponse.created_at`
>     - `EffectResponse.created_at`
>     - `TradeResponse.ledger_close_time`
>     - `OfferResponse.last_modified_time` (now `DateTimeOffset?`)
>     - `SorobanRpc.GetEventsResponse.EventInfo.ledgerClosedAt`
>   - Add `ClaimableBalanceResponse.last_modified_time: DateTimeOffset`.
> - **Tests**:
>   - Update expectations to `DateTimeOffset` and align sample data (offers, trades, ledgers, claimable balances, Soroban events).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0911be78c143305f1f2264f1d6f2ec47ea03babf. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->