### PR TITLE
chore: enable `RespectNullableAnnotations`

### DIFF
--- a/StellarDotnetSdk.Tests/Converters/JsonOptionsTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/JsonOptionsTest.cs
@@ -107,7 +107,7 @@ public class JsonOptionsTest
     ///     Verifies that the shared options reject such malformed payloads.
     /// </summary>
     [TestMethod]
-    public void Deserialize_NullValueForNonNullableProperty_Throws()
+    public void Deserialize_NullValueForNonNullableProperty_ThrowsJsonException()
     {
         // Arrange
         const string json = """{"Name":null,"Description":null}""";

--- a/StellarDotnetSdk.Tests/Converters/JsonOptionsTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/JsonOptionsTest.cs
@@ -92,6 +92,76 @@ public class JsonOptionsTest
     }
 
     /// <summary>
+    ///     Verifies that <see cref="JsonOptions.DefaultOptions" /> has
+    ///     <see cref="JsonSerializerOptions.RespectNullableAnnotations" /> enabled.
+    /// </summary>
+    [TestMethod]
+    public void DefaultOptions_RespectNullableAnnotations_IsEnabled()
+    {
+        // Act & Assert
+        Assert.IsTrue(JsonOptions.DefaultOptions.RespectNullableAnnotations);
+    }
+
+    /// <summary>
+    ///     Tests deserialization of JSON where a non-nullable reference property is null.
+    ///     Verifies that the shared options reject such malformed payloads.
+    /// </summary>
+    [TestMethod]
+    public void Deserialize_NullValueForNonNullableProperty_Throws()
+    {
+        // Arrange
+        const string json = """{"Name":null,"Description":null}""";
+
+        // Act & Assert
+        Assert.ThrowsException<JsonException>(() =>
+            JsonSerializer.Deserialize<SampleDto>(json, JsonOptions.DefaultOptions));
+    }
+
+    /// <summary>
+    ///     Tests deserialization of JSON where a nullable reference property is null.
+    ///     Verifies that the shared options still accept null values for nullable properties.
+    /// </summary>
+    [TestMethod]
+    public void Deserialize_NullValueForNullableProperty_Succeeds()
+    {
+        // Arrange
+        const string json = """{"Name":"alice","Description":null}""";
+
+        // Act
+        var result = JsonSerializer.Deserialize<SampleDto>(json, JsonOptions.DefaultOptions);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual("alice", result.Name);
+        Assert.IsNull(result.Description);
+    }
+
+    /// <summary>
+    ///     Tests deserialization of a valid JSON payload with all non-null values.
+    ///     Verifies that normal payloads still deserialize successfully.
+    /// </summary>
+    [TestMethod]
+    public void Deserialize_ValidPayload_Succeeds()
+    {
+        // Arrange
+        const string json = """{"Name":"alice","Description":"test"}""";
+
+        // Act
+        var result = JsonSerializer.Deserialize<SampleDto>(json, JsonOptions.DefaultOptions);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual("alice", result.Name);
+        Assert.AreEqual("test", result.Description);
+    }
+
+    private sealed class SampleDto
+    {
+        public string Name { get; set; } = string.Empty;
+        public string? Description { get; set; }
+    }
+
+    /// <summary>
     ///     A sample payload shape used to exercise duplicate-property rejection.
     /// </summary>
     private sealed record Payment(

--- a/StellarDotnetSdk/Converters/JsonOptions.cs
+++ b/StellarDotnetSdk/Converters/JsonOptions.cs
@@ -20,6 +20,8 @@ public static class JsonOptions
     ///     - PropertyNameCaseInsensitive: Allows flexible property matching
     ///     - AllowDuplicateProperties: Rejects JSON payloads that contain the same property more than once,
     ///     preventing silent data corruption from malformed responses (critical for financial data integrity).
+    ///     - RespectNullableAnnotations: Enforces C# nullability annotations during (de)serialization,
+    ///     so malformed API responses that violate the SDK's nullability contract fail fast.
     ///     Registered Converters:
     ///     - Polymorphic converters: OperationResponse, EffectResponse, Predicate
     ///     - Domain type converters: Asset, AssetAmount, KeyPair, LiquidityPoolId, LiquidityPoolClaimableAssetAmount, Reserve
@@ -38,6 +40,9 @@ public static class JsonOptions
         // Malformed or adversarial responses could otherwise overwrite financial fields (amount,
         // balance, destination) with attacker-controlled values without any error.
         AllowDuplicateProperties = false,
+
+        // Enforce C# nullability annotations so null values for non-nullable properties are rejected
+        RespectNullableAnnotations = true,
 
         Converters =
         {


### PR DESCRIPTION
This PR addresses #167.

## Auto-generated Summary 🤖

<!-- Copilot: generate the summary here -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
