### PR TITLE
chore!: use `JsonSerializerOptions.MakeReadOnly()` for shared options

### DIFF
--- a/StellarDotnetSdk.Tests/Converters/JsonOptionsTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/JsonOptionsTest.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using StellarDotnetSdk.Converters;
 
@@ -155,10 +157,56 @@ public class JsonOptionsTest
         Assert.AreEqual("test", result.Description);
     }
 
+    /// <summary>
+    ///     The shared options instance reports itself as read-only.
+    /// </summary>
+    [TestMethod]
+    public void DefaultOptions_IsReadOnly()
+    {
+        Assert.IsTrue(JsonOptions.DefaultOptions.IsReadOnly);
+    }
+
+    /// <summary>
+    ///     Attempting to add a converter to the frozen options throws <see cref="InvalidOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void DefaultOptions_AddConverter_Throws()
+    {
+        Assert.ThrowsException<InvalidOperationException>(() =>
+            JsonOptions.DefaultOptions.Converters.Add(new JsonStringEnumConverter()));
+    }
+
+    /// <summary>
+    ///     Attempting to mutate a scalar setting on the frozen options throws <see cref="InvalidOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void DefaultOptions_SetPropertyNameCaseInsensitive_Throws()
+    {
+        Assert.ThrowsException<InvalidOperationException>(() =>
+            JsonOptions.DefaultOptions.PropertyNameCaseInsensitive = false);
+    }
+
+    /// <summary>
+    ///     Smoke test: freezing the options does not break basic serialization/deserialization.
+    /// </summary>
+    [TestMethod]
+    public void DefaultOptions_StillSerializesAndDeserializes()
+    {
+        var payload = new SampleDto { Name = "stellar", Count = 42 };
+
+        var json = JsonSerializer.Serialize(payload, JsonOptions.DefaultOptions);
+        var roundTripped = JsonSerializer.Deserialize<SampleDto>(json, JsonOptions.DefaultOptions);
+
+        Assert.IsNotNull(roundTripped);
+        Assert.AreEqual(payload.Name, roundTripped!.Name);
+        Assert.AreEqual(payload.Count, roundTripped.Count);
+    }
+
     private sealed class SampleDto
     {
         public string Name { get; set; } = string.Empty;
         public string? Description { get; set; }
+        public int Count { get; set; }
     }
 
     /// <summary>

--- a/StellarDotnetSdk/Converters/JsonOptions.cs
+++ b/StellarDotnetSdk/Converters/JsonOptions.cs
@@ -13,6 +13,8 @@ public static class JsonOptions
 {
     /// <summary>
     ///     Default JSON serializer options with all custom converters registered.
+    ///     The instance is frozen via <see cref="JsonSerializerOptions.MakeReadOnly()" />
+    ///     to prevent accidental modification at runtime.
     /// </summary>
     /// <remarks>
     ///     Configuration:
@@ -28,45 +30,56 @@ public static class JsonOptions
     ///     - Enum converters: LiquidityPoolTypeEnum, SendTransactionStatusEnum, JsonStringEnumConverter (standard)
     ///     - HATEOAS link converters: LinkJsonConverter for EffectResponse and Response
     /// </remarks>
-    public static JsonSerializerOptions DefaultOptions { get; } = new()
+    public static readonly JsonSerializerOptions DefaultOptions = CreateDefaultOptions();
+
+    private static JsonSerializerOptions CreateDefaultOptions()
     {
-        // Allow deserializing numbers from strings (API sometimes returns "123" instead of 123)
-        NumberHandling = JsonNumberHandling.AllowReadingFromString,
-
-        // Case-insensitive property matching
-        PropertyNameCaseInsensitive = true,
-
-        // Reject JSON payloads with duplicate property names to prevent silent data corruption.
-        // Malformed or adversarial responses could otherwise overwrite financial fields (amount,
-        // balance, destination) with attacker-controlled values without any error.
-        AllowDuplicateProperties = false,
-
-        // Enforce C# nullability annotations so null values for non-nullable properties are rejected
-        RespectNullableAnnotations = true,
-
-        Converters =
+        var options = new JsonSerializerOptions
         {
-            // Polymorphic converters (MUST be registered globally)
-            new OperationResponseJsonConverter(),
-            new EffectResponseJsonConverter(),
-            new PredicateJsonConverter(),
+            // Allow deserializing numbers from strings (API sometimes returns "123" instead of 123)
+            NumberHandling = JsonNumberHandling.AllowReadingFromString,
 
-            // Domain type converters
-            new AssetJsonConverter(),
-            new AssetAmountJsonConverter(),
-            new KeyPairJsonConverter(),
-            new LiquidityPoolTypeEnumJsonConverter(),
-            new LiquidityPoolIdJsonConverter(),
-            new LiquidityPoolClaimableAssetAmountJsonConverter(),
-            new ReserveJsonConverter(),
+            // Case-insensitive property matching
+            PropertyNameCaseInsensitive = true,
 
-            // HATEOAS link converters
-            new LinkJsonConverter<EffectResponse>(),
-            new LinkJsonConverter<Response>(),
+            // Reject JSON payloads with duplicate property names to prevent silent data corruption.
+            // Malformed or adversarial responses could otherwise overwrite financial fields (amount,
+            // balance, destination) with attacker-controlled values without any error.
+            AllowDuplicateProperties = false,
 
-            // Enum converters
-            new JsonStringEnumConverter(),
-            new SendTransactionStatusEnumJsonConverter(),
-        },
-    };
+            // Enforce C# nullability annotations so null values for non-nullable properties are rejected
+            RespectNullableAnnotations = true,
+
+            Converters =
+            {
+                // Polymorphic converters (MUST be registered globally)
+                new OperationResponseJsonConverter(),
+                new EffectResponseJsonConverter(),
+                new PredicateJsonConverter(),
+
+                // Domain type converters
+                new AssetJsonConverter(),
+                new AssetAmountJsonConverter(),
+                new KeyPairJsonConverter(),
+                new LiquidityPoolTypeEnumJsonConverter(),
+                new LiquidityPoolIdJsonConverter(),
+                new LiquidityPoolClaimableAssetAmountJsonConverter(),
+                new ReserveJsonConverter(),
+
+                // HATEOAS link converters
+                new LinkJsonConverter<EffectResponse>(),
+                new LinkJsonConverter<Response>(),
+
+                // Enum converters
+                new JsonStringEnumConverter(),
+                new SendTransactionStatusEnumJsonConverter(),
+            },
+        };
+
+        // Freeze the options to prevent accidental modification of the shared singleton.
+        // populateMissingResolver: true installs the default reflection-based TypeInfoResolver,
+        // which matches the SDK's existing serialization behavior.
+        options.MakeReadOnly(true);
+        return options;
+    }
 }


### PR DESCRIPTION
This PR addresses #168.
## Auto-generated Summary 🤖

<!-- Copilot: generate the summary here -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
