### PR TITLE
feat: add integration test suite (phase 1)

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,39 @@
+name: Integration Tests
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+defaults:
+  run:
+    shell: pwsh
+jobs:
+  integration_tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Run integration tests
+        env:
+          INTEGRATION_HORIZON_URL:     ${{ vars.INTEGRATION_HORIZON_URL     || 'https://horizon-testnet.stellar.org' }}
+          INTEGRATION_SOROBAN_RPC_URL: ${{ vars.INTEGRATION_SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org' }}
+        run: |
+          dotnet test StellarDotnetSdk.IntegrationTests/StellarDotnetSdk.IntegrationTests.csproj `
+            --configuration Release `
+            --logger "console;verbosity=normal" `
+            --logger "trx;LogFileName=integration.trx"
+      - name: Upload TRX
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-trx
+          path: '**/integration.trx'
+          if-no-files-found: warn

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,6 +1,8 @@
 name: Integration Tests
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
   workflow_dispatch:
@@ -23,8 +25,10 @@ jobs:
           dotnet-version: '8.0.x'
       - name: Run integration tests
         env:
-          INTEGRATION_HORIZON_URL:     ${{ vars.INTEGRATION_HORIZON_URL     || 'https://horizon-testnet.stellar.org' }}
-          INTEGRATION_SOROBAN_RPC_URL: ${{ vars.INTEGRATION_SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org' }}
+          INTEGRATION_HORIZON_URL:       ${{ vars.INTEGRATION_HORIZON_URL       || 'https://horizon-testnet.stellar.org' }}
+          INTEGRATION_HORIZON_TOKEN:     ${{ secrets.INTEGRATION_HORIZON_TOKEN }}
+          INTEGRATION_STELLAR_RPC_URL:   ${{ vars.INTEGRATION_STELLAR_RPC_URL   || 'https://soroban-testnet.stellar.org' }}
+          INTEGRATION_STELLAR_RPC_TOKEN: ${{ secrets.INTEGRATION_STELLAR_RPC_TOKEN }}
         run: |
           dotnet test StellarDotnetSdk.IntegrationTests/StellarDotnetSdk.IntegrationTests.csproj `
             --configuration Release `

--- a/.github/workflows/pack_and_test.yml
+++ b/.github/workflows/pack_and_test.yml
@@ -32,5 +32,5 @@ jobs:
         uses: actions/setup-dotnet@v4
       - name: Pack
         run: dotnet pack --configuration Release --output ${{env.NuGetDirectory}}
-      - name: Run tests
-        run: dotnet test --configuration Release
+      - name: Run unit tests
+        run: dotnet test StellarDotnetSdk.Tests/StellarDotnetSdk.Tests.csproj --configuration Release

--- a/StellarDotnetSdk.IntegrationTests/Friendbot/FriendbotTests.cs
+++ b/StellarDotnetSdk.IntegrationTests/Friendbot/FriendbotTests.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using StellarDotnetSdk.IntegrationTests.Infrastructure;
+
+namespace StellarDotnetSdk.IntegrationTests.Friendbot;
+
+[TestFixture]
+[CancelAfter(60_000)]
+public class FriendbotTests : IntegrationTestBase
+{
+    [Test]
+    public async Task FundAccount_WithNewKeypair_CreatesAccountOnChain()
+    {
+        var keyPair = await CreateFundedAccountAsync();
+
+        var account = await LoadAccountAsync(keyPair);
+
+        account.AccountId.Should().Be(keyPair.AccountId);
+        account.SequenceNumber.Should().BeGreaterThan(0);
+        account.Balances.Should().NotBeEmpty();
+        account.Balances.Any(b => b.AssetType == "native").Should().BeTrue();
+    }
+}

--- a/StellarDotnetSdk.IntegrationTests/Horizon/RootTests.cs
+++ b/StellarDotnetSdk.IntegrationTests/Horizon/RootTests.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using StellarDotnetSdk.IntegrationTests.Infrastructure;
+
+namespace StellarDotnetSdk.IntegrationTests.Horizon;
+
+[TestFixture]
+[CancelAfter(30_000)]
+public class RootTests : IntegrationTestBase
+{
+    [Test]
+    public async Task RootAsync_OnTestnet_ReturnsPassphraseAndSupportedProtocol()
+    {
+        var root = await Server.RootAsync();
+
+        root.Should().NotBeNull();
+        root!.NetworkPassphrase.Should().Be(TestnetConfig.NetworkPassphrase);
+        root.CurrentProtocolVersion.Should().BeGreaterThanOrEqualTo(20);
+        root.HorizonVersion.Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/StellarDotnetSdk.IntegrationTests/Horizon/SubmitTransactionTests.cs
+++ b/StellarDotnetSdk.IntegrationTests/Horizon/SubmitTransactionTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using StellarDotnetSdk.Accounts;
+using StellarDotnetSdk.Assets;
+using StellarDotnetSdk.IntegrationTests.Infrastructure;
+using StellarDotnetSdk.Operations;
+using StellarDotnetSdk.Requests;
+using StellarDotnetSdk.Responses;
+using StellarDotnetSdk.Transactions;
+
+namespace StellarDotnetSdk.IntegrationTests.Horizon;
+
+[TestFixture]
+[CancelAfter(120_000)]
+public class SubmitTransactionTests : IntegrationTestBase
+{
+    [Test]
+    public async Task SubmitTransaction_WithSignedPayment_Succeeds()
+    {
+        var source = await CreateFundedAccountAsync();
+        var destination = await CreateFundedAccountAsync();
+
+        var tx = await BuildPaymentTransactionAsync(source, destination, "1");
+        tx.Sign(source);
+
+        var response = await Server.SubmitTransaction(tx);
+
+        response.Should().NotBeNull();
+        response!.IsSuccess.Should().BeTrue();
+        response.Hash.Should().Be(Convert.ToHexString(tx.Hash()).ToLowerInvariant());
+    }
+
+    [Test]
+    public async Task SubmitTransactionAsync_WithSignedPayment_ReturnsPendingThenResolves()
+    {
+        var source = await CreateFundedAccountAsync();
+        var destination = await CreateFundedAccountAsync();
+
+        var tx = await BuildPaymentTransactionAsync(source, destination, "1");
+        tx.Sign(source);
+
+        var response = await Server.SubmitTransactionAsync(tx);
+        response.Should().NotBeNull();
+        response!.TxStatus.Should().BeOneOf(
+            SubmitTransactionAsyncResponse.TransactionStatus.PENDING,
+            SubmitTransactionAsyncResponse.TransactionStatus.DUPLICATE);
+
+        var hash = response.Hash;
+        hash.Should().NotBeNullOrEmpty();
+
+        // Poll up to 30s for the transaction to be included in a ledger.
+        var deadline = DateTime.UtcNow.AddSeconds(30);
+        TransactionResponse? included = null;
+        while (DateTime.UtcNow < deadline && included is null)
+        {
+            try
+            {
+                included = await Server.Transactions.Transaction(hash!);
+            }
+            catch (HttpResponseException ex) when (ex.StatusCode == 404)
+            {
+                // Not yet in a ledger; back off briefly and retry.
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+        }
+
+        included.Should().NotBeNull($"transaction {hash} did not appear in a ledger within 30s");
+        included!.Successful.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task SubmitTransaction_WithFeeBump_Succeeds()
+    {
+        var source = await CreateFundedAccountAsync();
+        var destination = await CreateFundedAccountAsync();
+        var feeSource = await CreateFundedAccountAsync();
+
+        var inner = await BuildPaymentTransactionAsync(source, destination, "1");
+        inner.Sign(source);
+
+        var feeBump = TransactionBuilder.BuildFeeBumpTransaction(feeSource, inner);
+        feeBump.Sign(feeSource);
+
+        var response = await Server.SubmitTransaction(feeBump);
+
+        response.Should().NotBeNull();
+        response!.IsSuccess.Should().BeTrue();
+    }
+
+    private async Task<Transaction> BuildPaymentTransactionAsync(KeyPair source, KeyPair destination, string amountXlm)
+    {
+        var sourceAccount = await Server.Accounts.Account(source.AccountId);
+        var payment = new PaymentOperation(destination, new AssetTypeNative(), amountXlm);
+        return new TransactionBuilder(sourceAccount)
+            .AddOperation(payment)
+            .Build();
+    }
+}

--- a/StellarDotnetSdk.IntegrationTests/Infrastructure/IntegrationTestBase.cs
+++ b/StellarDotnetSdk.IntegrationTests/Infrastructure/IntegrationTestBase.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using StellarDotnetSdk.Accounts;
+using StellarDotnetSdk.Exceptions;
+using StellarDotnetSdk.Responses;
+
+namespace StellarDotnetSdk.IntegrationTests.Infrastructure;
+
+/// <summary>
+///     Base class for Testnet integration tests. Owns a single Server instance per
+///     test class lifecycle, configures the Testnet network, and exposes helpers
+///     for funding fresh keypairs via Friendbot with bounded retries.
+/// </summary>
+public abstract class IntegrationTestBase
+{
+    private static readonly TimeSpan[] BackoffDelays =
+    {
+        TimeSpan.FromSeconds(1),
+        TimeSpan.FromSeconds(3),
+        TimeSpan.FromSeconds(9),
+    };
+
+    protected Server Server = null!;
+
+    [OneTimeSetUp]
+    public void BaseOneTimeSetUp()
+    {
+        Network.UseTestNetwork();
+        Server = new Server(TestnetConfig.HorizonUrl);
+    }
+
+    [OneTimeTearDown]
+    public void BaseOneTimeTearDown()
+    {
+        Server.Dispose();
+    }
+
+    /// <summary>
+    ///     Generates a fresh random keypair and funds it via the Testnet Friendbot.
+    ///     Retries on transient errors (up to 4 attempts: an initial try plus 3 retries with 1s/3s/9s backoff).
+    /// </summary>
+    protected async Task<KeyPair> CreateFundedAccountAsync()
+    {
+        var keyPair = KeyPair.Random();
+        await FundWithRetryAsync(keyPair.AccountId);
+        return keyPair;
+    }
+
+    /// <summary>
+    ///     Loads the on-chain account state for the given keypair (sequence number, balances, etc).
+    /// </summary>
+    protected Task<AccountResponse> LoadAccountAsync(KeyPair keyPair)
+    {
+        return Server.Accounts.Account(keyPair.AccountId);
+    }
+
+    private async Task FundWithRetryAsync(string accountId)
+    {
+        Exception? lastException = null;
+
+        // One initial attempt, then one retry after each backoff delay (BackoffDelays.Length + 1 total).
+        var totalAttempts = BackoffDelays.Length + 1;
+        for (var attempt = 0; attempt < totalAttempts; attempt++)
+        {
+            try
+            {
+                var response = await Server.TestNetFriendBot.FundAccount(accountId).Execute();
+                if (!string.IsNullOrEmpty(response.Hash))
+                {
+                    return;
+                }
+
+                // Friendbot returned a body without Hash (e.g. error envelope).
+                lastException = new InvalidOperationException(
+                    $"Friendbot did not return a transaction hash for {accountId}. " +
+                    $"Status={response.Status}, Title={response.Title}, Detail={response.Detail}");
+            }
+            catch (TooManyRequestsException ex)
+            {
+                lastException = ex;
+            }
+            catch (ServiceUnavailableException ex)
+            {
+                lastException = ex;
+            }
+            catch (HttpRequestException ex) // transient network error
+            {
+                lastException = ex;
+            }
+
+            // Sleep before the next attempt, but not after the final one.
+            if (attempt < BackoffDelays.Length)
+            {
+                await Task.Delay(BackoffDelays[attempt]);
+            }
+        }
+
+        Assert.Inconclusive(
+            $"Friendbot funding failed after {totalAttempts} attempts for {accountId}. " +
+            $"This is likely a Testnet rate-limit or outage, not an SDK regression. " +
+            $"Last error: {lastException?.Message}");
+    }
+}

--- a/StellarDotnetSdk.IntegrationTests/Infrastructure/IntegrationTestBase.cs
+++ b/StellarDotnetSdk.IntegrationTests/Infrastructure/IntegrationTestBase.cs
@@ -9,9 +9,15 @@ using StellarDotnetSdk.Responses;
 namespace StellarDotnetSdk.IntegrationTests.Infrastructure;
 
 /// <summary>
-///     Base class for Testnet integration tests. Owns a single Server instance per
-///     test class lifecycle, configures the Testnet network, and exposes helpers
-///     for funding fresh keypairs via Friendbot with bounded retries.
+///     Base class for Testnet integration tests. Owns the Server clients per test-class
+///     lifecycle and configures the Testnet network.
+///     <para>
+///         <see cref="Server" /> handles all reads and submissions and may be routed to an
+///         authenticated provider (e.g. Blockdaemon) via <c>INTEGRATION_HORIZON_URL</c> +
+///         <c>INTEGRATION_HORIZON_TOKEN</c>. Friendbot funding uses a separate client
+///         (<see cref="_fundingServer" />) pinned to Stellar's public Testnet, because the
+///         Friendbot faucet is SDF-only and not hosted by most providers.
+///     </para>
 /// </summary>
 public abstract class IntegrationTestBase
 {
@@ -26,19 +32,25 @@ public abstract class IntegrationTestBase
     // cannot blow a test's [CancelAfter] budget.
     private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromSeconds(15);
 
+    /// <summary>Client used solely for Friendbot funding, pinned to a faucet-capable Horizon.</summary>
+    private Server _fundingServer = null!;
+
+    /// <summary>Client for reads and submissions; honors the optional Horizon bearer token.</summary>
     protected Server Server = null!;
 
     [OneTimeSetUp]
     public void BaseOneTimeSetUp()
     {
         Network.UseTestNetwork();
-        Server = new Server(TestnetConfig.HorizonUrl);
+        Server = new Server(TestnetConfig.HorizonUrl, TestnetConfig.HorizonToken);
+        _fundingServer = new Server(TestnetConfig.FriendbotUrl);
     }
 
     [OneTimeTearDown]
     public void BaseOneTimeTearDown()
     {
         Server.Dispose();
+        _fundingServer.Dispose();
     }
 
     /// <summary>
@@ -73,7 +85,7 @@ public abstract class IntegrationTestBase
 
             try
             {
-                var response = await Server.TestNetFriendBot.FundAccount(accountId).Execute();
+                var response = await _fundingServer.TestNetFriendBot.FundAccount(accountId).Execute();
                 if (!string.IsNullOrEmpty(response.Hash))
                 {
                     return;
@@ -106,7 +118,7 @@ public abstract class IntegrationTestBase
                 // MaxRetryDelay; otherwise fall back to the fixed exponential backoff.
                 var backoff = BackoffDelays[attempt];
                 var delay = retryAfter is { } ra && ra > backoff
-                    ? (ra < MaxRetryDelay ? ra : MaxRetryDelay)
+                    ? ra < MaxRetryDelay ? ra : MaxRetryDelay
                     : backoff;
                 await Task.Delay(delay);
             }

--- a/StellarDotnetSdk.IntegrationTests/Infrastructure/IntegrationTestBase.cs
+++ b/StellarDotnetSdk.IntegrationTests/Infrastructure/IntegrationTestBase.cs
@@ -22,6 +22,10 @@ public abstract class IntegrationTestBase
         TimeSpan.FromSeconds(9),
     };
 
+    // Upper bound on a single honored Retry-After wait, so one server-advised delay
+    // cannot blow a test's [CancelAfter] budget.
+    private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromSeconds(15);
+
     protected Server Server = null!;
 
     [OneTimeSetUp]
@@ -64,6 +68,9 @@ public abstract class IntegrationTestBase
         var totalAttempts = BackoffDelays.Length + 1;
         for (var attempt = 0; attempt < totalAttempts; attempt++)
         {
+            // Server-advised Retry-After for this attempt, if the failure carried one.
+            TimeSpan? retryAfter = null;
+
             try
             {
                 var response = await Server.TestNetFriendBot.FundAccount(accountId).Execute();
@@ -80,10 +87,12 @@ public abstract class IntegrationTestBase
             catch (TooManyRequestsException ex)
             {
                 lastException = ex;
+                retryAfter = ex.RetryAfterDelay;
             }
             catch (ServiceUnavailableException ex)
             {
                 lastException = ex;
+                retryAfter = ex.RetryAfterDelay;
             }
             catch (HttpRequestException ex) // transient network error
             {
@@ -93,7 +102,13 @@ public abstract class IntegrationTestBase
             // Sleep before the next attempt, but not after the final one.
             if (attempt < BackoffDelays.Length)
             {
-                await Task.Delay(BackoffDelays[attempt]);
+                // Honor the server-advised Retry-After when present (RFC 7231), clamped to
+                // MaxRetryDelay; otherwise fall back to the fixed exponential backoff.
+                var backoff = BackoffDelays[attempt];
+                var delay = retryAfter is { } ra && ra > backoff
+                    ? (ra < MaxRetryDelay ? ra : MaxRetryDelay)
+                    : backoff;
+                await Task.Delay(delay);
             }
         }
 

--- a/StellarDotnetSdk.IntegrationTests/Infrastructure/TestnetConfig.cs
+++ b/StellarDotnetSdk.IntegrationTests/Infrastructure/TestnetConfig.cs
@@ -4,17 +4,47 @@ namespace StellarDotnetSdk.IntegrationTests.Infrastructure;
 
 /// <summary>
 ///     Central, environment-overridable configuration for the integration tests.
-///     Defaults point at the public Stellar Testnet; CI may override via env vars.
+///     Defaults point at the public Stellar Testnet; CI may override via env vars
+///     (e.g. to route the data plane through an authenticated provider like Blockdaemon).
 /// </summary>
 public static class TestnetConfig
 {
+    /// <summary>Horizon base URL for all reads and submissions. Override to a provider endpoint.</summary>
     public static string HorizonUrl => Env("INTEGRATION_HORIZON_URL", "https://horizon-testnet.stellar.org");
-    public static string SorobanRpcUrl => Env("INTEGRATION_SOROBAN_RPC_URL", "https://soroban-testnet.stellar.org");
+
+    /// <summary>
+    ///     Optional bearer token for <see cref="HorizonUrl" /> (e.g. a Blockdaemon API key).
+    ///     Null when unset, in which case requests are unauthenticated.
+    /// </summary>
+    public static string? HorizonToken => EnvOrNull("INTEGRATION_HORIZON_TOKEN");
+
+    /// <summary>
+    ///     Horizon base URL used only for Friendbot funding. Defaults to Stellar's public Testnet,
+    ///     which hosts the Friendbot faucet; most providers (Blockdaemon included) do not, so funding
+    ///     stays here even when <see cref="HorizonUrl" /> points elsewhere.
+    /// </summary>
+    public static string FriendbotUrl => Env("INTEGRATION_FRIENDBOT_URL", "https://horizon-testnet.stellar.org");
+
+    /// <summary>
+    ///     Stellar RPC (formerly Soroban RPC) base URL. Consumed by Soroban tests in a later phase.
+    ///     The public Testnet host is still <c>soroban-testnet.stellar.org</c> despite the renamed term.
+    /// </summary>
+    public static string StellarRpcUrl => Env("INTEGRATION_STELLAR_RPC_URL", "https://soroban-testnet.stellar.org");
+
+    /// <summary>Optional bearer token for <see cref="StellarRpcUrl" />. Null when unset.</summary>
+    public static string? StellarRpcToken => EnvOrNull("INTEGRATION_STELLAR_RPC_TOKEN");
+
     public static string NetworkPassphrase => Network.TestnetPassphrase;
 
     private static string Env(string key, string fallback)
     {
         var value = Environment.GetEnvironmentVariable(key);
         return string.IsNullOrWhiteSpace(value) ? fallback : value;
+    }
+
+    private static string? EnvOrNull(string key)
+    {
+        var value = Environment.GetEnvironmentVariable(key);
+        return string.IsNullOrWhiteSpace(value) ? null : value;
     }
 }

--- a/StellarDotnetSdk.IntegrationTests/Infrastructure/TestnetConfig.cs
+++ b/StellarDotnetSdk.IntegrationTests/Infrastructure/TestnetConfig.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace StellarDotnetSdk.IntegrationTests.Infrastructure;
+
+/// <summary>
+///     Central, environment-overridable configuration for the integration tests.
+///     Defaults point at the public Stellar Testnet; CI may override via env vars.
+/// </summary>
+public static class TestnetConfig
+{
+    public static string HorizonUrl => Env("INTEGRATION_HORIZON_URL", "https://horizon-testnet.stellar.org");
+    public static string SorobanRpcUrl => Env("INTEGRATION_SOROBAN_RPC_URL", "https://soroban-testnet.stellar.org");
+    public static string NetworkPassphrase => Network.TestnetPassphrase;
+
+    private static string Env(string key, string fallback)
+    {
+        var value = Environment.GetEnvironmentVariable(key);
+        return string.IsNullOrWhiteSpace(value) ? fallback : value;
+    }
+}

--- a/StellarDotnetSdk.IntegrationTests/Infrastructure/TestnetConfigTests.cs
+++ b/StellarDotnetSdk.IntegrationTests/Infrastructure/TestnetConfigTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -11,21 +12,32 @@ public class TestnetConfigTests
     [SetUp]
     public void SetUp()
     {
-        _originalHorizonUrl = Environment.GetEnvironmentVariable("INTEGRATION_HORIZON_URL");
-        _originalSorobanRpcUrl = Environment.GetEnvironmentVariable("INTEGRATION_SOROBAN_RPC_URL");
-        Environment.SetEnvironmentVariable("INTEGRATION_HORIZON_URL", null);
-        Environment.SetEnvironmentVariable("INTEGRATION_SOROBAN_RPC_URL", null);
+        foreach (var key in ManagedVars)
+        {
+            _originalValues[key] = Environment.GetEnvironmentVariable(key);
+            Environment.SetEnvironmentVariable(key, null);
+        }
     }
 
     [TearDown]
     public void TearDown()
     {
-        Environment.SetEnvironmentVariable("INTEGRATION_HORIZON_URL", _originalHorizonUrl);
-        Environment.SetEnvironmentVariable("INTEGRATION_SOROBAN_RPC_URL", _originalSorobanRpcUrl);
+        foreach (var key in ManagedVars)
+        {
+            Environment.SetEnvironmentVariable(key, _originalValues[key]);
+        }
     }
 
-    private string? _originalHorizonUrl;
-    private string? _originalSorobanRpcUrl;
+    private static readonly string[] ManagedVars =
+    {
+        "INTEGRATION_HORIZON_URL",
+        "INTEGRATION_HORIZON_TOKEN",
+        "INTEGRATION_FRIENDBOT_URL",
+        "INTEGRATION_STELLAR_RPC_URL",
+        "INTEGRATION_STELLAR_RPC_TOKEN",
+    };
+
+    private readonly Dictionary<string, string?> _originalValues = new();
 
     [Test]
     public void HorizonUrl_WhenEnvVarUnset_ReturnsPublicTestnetDefault()
@@ -48,16 +60,55 @@ public class TestnetConfigTests
     }
 
     [Test]
-    public void SorobanRpcUrl_WhenEnvVarUnset_ReturnsPublicTestnetDefault()
+    public void HorizonToken_WhenEnvVarUnset_ReturnsNull()
     {
-        TestnetConfig.SorobanRpcUrl.Should().Be("https://soroban-testnet.stellar.org");
+        TestnetConfig.HorizonToken.Should().BeNull();
     }
 
     [Test]
-    public void SorobanRpcUrl_WhenEnvVarSet_ReturnsConfiguredValue()
+    public void HorizonToken_WhenEnvVarSet_ReturnsConfiguredValue()
     {
-        Environment.SetEnvironmentVariable("INTEGRATION_SOROBAN_RPC_URL", "https://soroban.example.com");
-        TestnetConfig.SorobanRpcUrl.Should().Be("https://soroban.example.com");
+        Environment.SetEnvironmentVariable("INTEGRATION_HORIZON_TOKEN", "secret-token");
+        TestnetConfig.HorizonToken.Should().Be("secret-token");
+    }
+
+    [Test]
+    public void FriendbotUrl_WhenEnvVarUnset_ReturnsPublicTestnetDefault()
+    {
+        TestnetConfig.FriendbotUrl.Should().Be("https://horizon-testnet.stellar.org");
+    }
+
+    [Test]
+    public void FriendbotUrl_WhenEnvVarSet_ReturnsConfiguredValue()
+    {
+        Environment.SetEnvironmentVariable("INTEGRATION_FRIENDBOT_URL", "https://friendbot.example.com");
+        TestnetConfig.FriendbotUrl.Should().Be("https://friendbot.example.com");
+    }
+
+    [Test]
+    public void StellarRpcUrl_WhenEnvVarUnset_ReturnsPublicTestnetDefault()
+    {
+        TestnetConfig.StellarRpcUrl.Should().Be("https://soroban-testnet.stellar.org");
+    }
+
+    [Test]
+    public void StellarRpcUrl_WhenEnvVarSet_ReturnsConfiguredValue()
+    {
+        Environment.SetEnvironmentVariable("INTEGRATION_STELLAR_RPC_URL", "https://rpc.example.com");
+        TestnetConfig.StellarRpcUrl.Should().Be("https://rpc.example.com");
+    }
+
+    [Test]
+    public void StellarRpcToken_WhenEnvVarUnset_ReturnsNull()
+    {
+        TestnetConfig.StellarRpcToken.Should().BeNull();
+    }
+
+    [Test]
+    public void StellarRpcToken_WhenEnvVarSet_ReturnsConfiguredValue()
+    {
+        Environment.SetEnvironmentVariable("INTEGRATION_STELLAR_RPC_TOKEN", "rpc-token");
+        TestnetConfig.StellarRpcToken.Should().Be("rpc-token");
     }
 
     [Test]

--- a/StellarDotnetSdk.IntegrationTests/Infrastructure/TestnetConfigTests.cs
+++ b/StellarDotnetSdk.IntegrationTests/Infrastructure/TestnetConfigTests.cs
@@ -1,0 +1,68 @@
+using System;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace StellarDotnetSdk.IntegrationTests.Infrastructure;
+
+[TestFixture]
+[NonParallelizable] // mutates process environment variables
+public class TestnetConfigTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        _originalHorizonUrl = Environment.GetEnvironmentVariable("INTEGRATION_HORIZON_URL");
+        _originalSorobanRpcUrl = Environment.GetEnvironmentVariable("INTEGRATION_SOROBAN_RPC_URL");
+        Environment.SetEnvironmentVariable("INTEGRATION_HORIZON_URL", null);
+        Environment.SetEnvironmentVariable("INTEGRATION_SOROBAN_RPC_URL", null);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable("INTEGRATION_HORIZON_URL", _originalHorizonUrl);
+        Environment.SetEnvironmentVariable("INTEGRATION_SOROBAN_RPC_URL", _originalSorobanRpcUrl);
+    }
+
+    private string? _originalHorizonUrl;
+    private string? _originalSorobanRpcUrl;
+
+    [Test]
+    public void HorizonUrl_WhenEnvVarUnset_ReturnsPublicTestnetDefault()
+    {
+        TestnetConfig.HorizonUrl.Should().Be("https://horizon-testnet.stellar.org");
+    }
+
+    [Test]
+    public void HorizonUrl_WhenEnvVarSet_ReturnsConfiguredValue()
+    {
+        Environment.SetEnvironmentVariable("INTEGRATION_HORIZON_URL", "https://horizon.example.com");
+        TestnetConfig.HorizonUrl.Should().Be("https://horizon.example.com");
+    }
+
+    [Test]
+    public void HorizonUrl_WhenEnvVarWhitespace_ReturnsPublicTestnetDefault()
+    {
+        Environment.SetEnvironmentVariable("INTEGRATION_HORIZON_URL", "   ");
+        TestnetConfig.HorizonUrl.Should().Be("https://horizon-testnet.stellar.org");
+    }
+
+    [Test]
+    public void SorobanRpcUrl_WhenEnvVarUnset_ReturnsPublicTestnetDefault()
+    {
+        TestnetConfig.SorobanRpcUrl.Should().Be("https://soroban-testnet.stellar.org");
+    }
+
+    [Test]
+    public void SorobanRpcUrl_WhenEnvVarSet_ReturnsConfiguredValue()
+    {
+        Environment.SetEnvironmentVariable("INTEGRATION_SOROBAN_RPC_URL", "https://soroban.example.com");
+        TestnetConfig.SorobanRpcUrl.Should().Be("https://soroban.example.com");
+    }
+
+    [Test]
+    public void NetworkPassphrase_ReturnsSdkTestnetConstant()
+    {
+        TestnetConfig.NetworkPassphrase.Should().Be(Network.TestnetPassphrase);
+    }
+}

--- a/StellarDotnetSdk.IntegrationTests/Operations/CreateAccountOperationTests.cs
+++ b/StellarDotnetSdk.IntegrationTests/Operations/CreateAccountOperationTests.cs
@@ -1,0 +1,40 @@
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using StellarDotnetSdk.Accounts;
+using StellarDotnetSdk.IntegrationTests.Infrastructure;
+using StellarDotnetSdk.Operations;
+using StellarDotnetSdk.Transactions;
+
+namespace StellarDotnetSdk.IntegrationTests.Operations;
+
+[TestFixture]
+[CancelAfter(60_000)]
+public class CreateAccountOperationTests : IntegrationTestBase
+{
+    [Test]
+    public async Task CreateAccountOperation_WithStartingBalance_CreatesAccountOnChain()
+    {
+        var funder = await CreateFundedAccountAsync();
+        var newAccount = KeyPair.Random();
+
+        var funderAccount = await Server.Accounts.Account(funder.AccountId);
+        var operation = new CreateAccountOperation(newAccount, "10");
+        var tx = new TransactionBuilder(funderAccount)
+            .AddOperation(operation)
+            .Build();
+        tx.Sign(funder);
+
+        var response = await Server.SubmitTransaction(tx);
+        response.Should().NotBeNull();
+        response!.IsSuccess.Should().BeTrue();
+
+        var created = await LoadAccountAsync(newAccount);
+        created.AccountId.Should().Be(newAccount.AccountId);
+        var nativeBalance = created.Balances.Single(b => b.AssetType == "native");
+        decimal.Parse(nativeBalance.BalanceString, CultureInfo.InvariantCulture)
+            .Should().Be(10m);
+    }
+}

--- a/StellarDotnetSdk.IntegrationTests/Operations/PaymentOperationTests.cs
+++ b/StellarDotnetSdk.IntegrationTests/Operations/PaymentOperationTests.cs
@@ -1,0 +1,46 @@
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using StellarDotnetSdk.Assets;
+using StellarDotnetSdk.IntegrationTests.Infrastructure;
+using StellarDotnetSdk.Operations;
+using StellarDotnetSdk.Transactions;
+
+namespace StellarDotnetSdk.IntegrationTests.Operations;
+
+[TestFixture]
+[CancelAfter(60_000)]
+public class PaymentOperationTests : IntegrationTestBase
+{
+    [Test]
+    public async Task PaymentOperation_WithNativeAsset_CreditsDestination()
+    {
+        var source = await CreateFundedAccountAsync();
+        var destination = await CreateFundedAccountAsync();
+
+        var destBefore = await LoadAccountAsync(destination);
+        var destNativeBefore = decimal.Parse(
+            destBefore.Balances.Single(b => b.AssetType == "native").BalanceString,
+            CultureInfo.InvariantCulture);
+
+        var sourceAccount = await Server.Accounts.Account(source.AccountId);
+        var payment = new PaymentOperation(destination, new AssetTypeNative(), "5");
+        var tx = new TransactionBuilder(sourceAccount)
+            .AddOperation(payment)
+            .Build();
+        tx.Sign(source);
+
+        var response = await Server.SubmitTransaction(tx);
+        response.Should().NotBeNull();
+        response!.IsSuccess.Should().BeTrue();
+
+        var destAfter = await LoadAccountAsync(destination);
+        var destNativeAfter = decimal.Parse(
+            destAfter.Balances.Single(b => b.AssetType == "native").BalanceString,
+            CultureInfo.InvariantCulture);
+
+        (destNativeAfter - destNativeBefore).Should().Be(5m);
+    }
+}

--- a/StellarDotnetSdk.IntegrationTests/README.md
+++ b/StellarDotnetSdk.IntegrationTests/README.md
@@ -1,30 +1,42 @@
 # StellarDotnetSdk.IntegrationTests
 
-End-to-end tests that exercise the SDK against the public Stellar **Testnet**.
+End-to-end tests that exercise the SDK against the Stellar **Testnet**.
 
 ## When this runs
 
 - **Locally:** `dotnet test StellarDotnetSdk.IntegrationTests/StellarDotnetSdk.IntegrationTests.csproj`
-- **CI:** `.github/workflows/integration_tests.yml` runs on every `v*` tag push and on `workflow_dispatch`.
-  It does **not** run on regular PRs (those use `pack_and_test.yml`, which only runs the unit project).
+- **CI:** `.github/workflows/integration_tests.yml` runs on pushes to `main`, on `v*` tag pushes,
+  and on `workflow_dispatch`. It does **not** run on regular PRs (those use `pack_and_test.yml`,
+  which only runs the unit project).
 
 ## Environment overrides
 
-| Variable                      | Default                               |
-|-------------------------------|---------------------------------------|
-| `INTEGRATION_HORIZON_URL`     | `https://horizon-testnet.stellar.org` |
-| `INTEGRATION_SOROBAN_RPC_URL` | `https://soroban-testnet.stellar.org` |
+The data plane (Horizon / Stellar RPC) defaults to Stellar's public Testnet, so outside
+contributors need no configuration. To route it to an authenticated provider instead, set
+these variables — URLs as repo `vars.*`, tokens as `secrets.*`:
 
-CI consumes these from repo `vars.*`; locally, set them in your shell.
+| Variable | Default | Purpose |
+|---|---|---|
+| `INTEGRATION_HORIZON_URL`       | `https://horizon-testnet.stellar.org` | Horizon base URL for reads/submissions |
+| `INTEGRATION_HORIZON_TOKEN`     | _(none)_                              | Bearer token for `INTEGRATION_HORIZON_URL` |
+| `INTEGRATION_FRIENDBOT_URL`     | `https://horizon-testnet.stellar.org` | Horizon used for Friendbot funding (see below) |
+| `INTEGRATION_STELLAR_RPC_URL`   | `https://soroban-testnet.stellar.org` | Stellar RPC base URL (used from Phase 2) |
+| `INTEGRATION_STELLAR_RPC_TOKEN` | _(none)_                              | Bearer token for `INTEGRATION_STELLAR_RPC_URL` |
+
+## Friendbot funding
+
+Funding always uses Stellar's public Testnet Friendbot, even when Horizon/RPC point at a
+provider — the Friendbot faucet is SDF-only and not hosted by most providers.
+`IntegrationTestBase` uses a dedicated funding client (`INTEGRATION_FRIENDBOT_URL`) for this,
+separate from the main client.
+
+Friendbot occasionally returns 429s. `IntegrationTestBase.CreateFundedAccountAsync` makes an
+initial attempt plus up to 3 backoff retries (1s/3s/9s, honoring a server `Retry-After` when
+present) before reporting the test as `Inconclusive` — that signals a Testnet outage or
+rate-limit, not an SDK regression.
 
 ## Testnet resets
 
-Stellar Testnet is reset roughly quarterly. These tests are resilient by design:
-every test generates its own keypair and funds it via Friendbot, so nothing
-on-chain is shared between tests or runs.
-
-## Friendbot rate limits
-
-Friendbot occasionally returns 429s. `IntegrationTestBase.CreateFundedAccountAsync`
-retries 3 times with exponential backoff (1s, 3s, 9s) before reporting the test
-as `Inconclusive` — that signals a Testnet outage, not an SDK regression.
+Stellar Testnet is reset roughly quarterly. These tests are resilient by design: every test
+generates its own keypair and funds it via Friendbot, so nothing on-chain is shared between
+tests or runs.

--- a/StellarDotnetSdk.IntegrationTests/README.md
+++ b/StellarDotnetSdk.IntegrationTests/README.md
@@ -1,0 +1,30 @@
+# StellarDotnetSdk.IntegrationTests
+
+End-to-end tests that exercise the SDK against the public Stellar **Testnet**.
+
+## When this runs
+
+- **Locally:** `dotnet test StellarDotnetSdk.IntegrationTests/StellarDotnetSdk.IntegrationTests.csproj`
+- **CI:** `.github/workflows/integration_tests.yml` runs on every `v*` tag push and on `workflow_dispatch`.
+  It does **not** run on regular PRs (those use `pack_and_test.yml`, which only runs the unit project).
+
+## Environment overrides
+
+| Variable                      | Default                               |
+|-------------------------------|---------------------------------------|
+| `INTEGRATION_HORIZON_URL`     | `https://horizon-testnet.stellar.org` |
+| `INTEGRATION_SOROBAN_RPC_URL` | `https://soroban-testnet.stellar.org` |
+
+CI consumes these from repo `vars.*`; locally, set them in your shell.
+
+## Testnet resets
+
+Stellar Testnet is reset roughly quarterly. These tests are resilient by design:
+every test generates its own keypair and funds it via Friendbot, so nothing
+on-chain is shared between tests or runs.
+
+## Friendbot rate limits
+
+Friendbot occasionally returns 429s. `IntegrationTestBase.CreateFundedAccountAsync`
+retries 3 times with exponential backoff (1s, 3s, 9s) before reporting the test
+as `Inconclusive` — that signals a Testnet outage, not an SDK regression.

--- a/StellarDotnetSdk.IntegrationTests/StellarDotnetSdk.IntegrationTests.csproj
+++ b/StellarDotnetSdk.IntegrationTests/StellarDotnetSdk.IntegrationTests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <Nullable>enable</Nullable>
+        <LangVersion>12</LangVersion>
+        <RootNamespace>StellarDotnetSdk.IntegrationTests</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.7.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="NUnit" Version="4.0.1"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\StellarDotnetSdk\StellarDotnetSdk.csproj"/>
+    </ItemGroup>
+</Project>

--- a/StellarDotnetSdk.Tests/StellarDotnetSdk.Tests.csproj
+++ b/StellarDotnetSdk.Tests/StellarDotnetSdk.Tests.csproj
@@ -20,8 +20,8 @@
         <PackageReference Include="Fare" Version="2.2.1"/>
         <PackageReference Include="FluentAssertions" Version="6.7.0"/>
         <PackageReference Include="FsCheck.NUnit" Version="2.16.5"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="Moq" Version="4.18.2"/>
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.10"/>
         <PackageReference Include="MSTest.TestFramework" Version="2.2.10"/>

--- a/stellar-dotnet-sdk.sln
+++ b/stellar-dotnet-sdk.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StellarDotnetSdk", "Stellar
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StellarDotnetSdk.Tests", "StellarDotnetSdk.Tests\StellarDotnetSdk.Tests.csproj", "{B005220F-602B-4888-A72F-A4583181773A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StellarDotnetSdk.IntegrationTests", "StellarDotnetSdk.IntegrationTests\StellarDotnetSdk.IntegrationTests.csproj", "{2B5775A5-0A56-46CF-8A1A-EA1FB1FE7B95}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StellarDotnetSdk.Console", "StellarDotnetSdk.Console\StellarDotnetSdk.Console.csproj", "{7BA6DFB8-5736-47EC-8995-E652D221E077}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StellarDotnetSdk.Xdr", "StellarDotnetSdk.Xdr\StellarDotnetSdk.Xdr.csproj", "{DB19EF41-BF22-41D0-B856-858C6FC17068}"
@@ -76,6 +78,10 @@ Global
 		{18FC119D-3D92-47F0-B0F5-F0E87B9D3FD4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{18FC119D-3D92-47F0-B0F5-F0E87B9D3FD4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{18FC119D-3D92-47F0-B0F5-F0E87B9D3FD4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B5775A5-0A56-46CF-8A1A-EA1FB1FE7B95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B5775A5-0A56-46CF-8A1A-EA1FB1FE7B95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B5775A5-0A56-46CF-8A1A-EA1FB1FE7B95}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B5775A5-0A56-46CF-8A1A-EA1FB1FE7B95}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Auto-generated Summary 🤖

<!-- Copilot: generate the summary here -->

## Summary

**Scope: Phase 1 of #156.** Establishes the integration-test foundation plus the highest-value happy-path coverage. Remaining areas follow in later phases.

First slice of an integration test suite that runs the SDK against the public Stellar **Testnet**:

- **New `StellarDotnetSdk.IntegrationTests` project** (NUnit + FluentAssertions), isolated from the unit tests.
- **Shared infrastructure** — `TestnetConfig` (env-overridable Horizon/Soroban URLs) and `IntegrationTestBase`, which sets the Testnet network and self-provisions funded accounts via Friendbot with bounded backoff retry. When Friendbot is rate-limited or Testnet is down, tests report **`Inconclusive`** (not failed), so environment flakiness isn't mistaken for an SDK regression.
  Every test mints its own keypairs, so Testnet resets don't affect it.
- **5 of the 17 Priority-1 areas** from #156: Friendbot funding, `Server.RootAsync`, `SubmitTransaction` (sync / async / fee-bump), `CreateAccountOperation`, and native `PaymentOperation`.
- **CI** — new `integration_tests.yml` gated on `v*` tags + manual `workflow_dispatch` (keeps Testnet off the per-PR path); `pack_and_test.yml` narrowed to the unit project so PR CI stays hermetic.

### Out of scope (future phases)
The remaining 12 Priority-1 areas (CheckMemoRequired; Accounts/Transactions/Payments request builders; path payments; ManageSell/BuyOffer; ChangeTrust/SetOptions; Soroban invoke + footprint + full RPC flow; SSE streaming; SEP-10) and the entire
Priority-2 backlog land in follow-up PRs.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
