### PR TITLE
chore!: use `Stream.ReadExactly()` in XDR binary decoding

### DIFF
--- a/StellarDotnetSdk.Tests/Xdr/XdrDataStreamTest.cs
+++ b/StellarDotnetSdk.Tests/Xdr/XdrDataStreamTest.cs
@@ -1,6 +1,10 @@
+using System;
+using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using StellarDotnetSdk.Xdr;
+using Int64 = StellarDotnetSdk.Xdr.Int64;
+using Uint64 = StellarDotnetSdk.Xdr.Uint64;
 
 namespace StellarDotnetSdk.Tests.Xdr;
 
@@ -91,5 +95,247 @@ public class XdrDataStreamTest
         // Assert
         Assert.IsTrue(expected.SequenceEqual(result));
         Assert.AreEqual(1, sentinel);
+    }
+
+    /// <summary>
+    ///     Verifies that XDR int values round-trip correctly through the data streams.
+    /// </summary>
+    [TestMethod]
+    public void ReadInt_WithRoundTrip_PreservesValues()
+    {
+        // Arrange
+        int[] values = [int.MinValue, -1, 0, 1, 42, int.MaxValue];
+        var outputStream = new XdrDataOutputStream();
+        foreach (var value in values)
+        {
+            outputStream.WriteInt(value);
+        }
+        var inputStream = new XdrDataInputStream(outputStream.ToArray());
+
+        // Act & Assert
+        foreach (var value in values)
+        {
+            Assert.AreEqual(value, inputStream.ReadInt());
+        }
+    }
+
+    /// <summary>
+    ///     Verifies that XDR uint values round-trip correctly through the data streams.
+    /// </summary>
+    [TestMethod]
+    public void ReadUInt_WithRoundTrip_PreservesValues()
+    {
+        // Arrange
+        uint[] values = [uint.MinValue, 1, 42, 0x80000000, uint.MaxValue];
+        var outputStream = new XdrDataOutputStream();
+        foreach (var value in values)
+        {
+            outputStream.WriteUInt(value);
+        }
+        var inputStream = new XdrDataInputStream(outputStream.ToArray());
+
+        // Act & Assert
+        foreach (var value in values)
+        {
+            Assert.AreEqual(value, inputStream.ReadUInt());
+        }
+    }
+
+    /// <summary>
+    ///     Verifies that XDR long values round-trip correctly through the data streams.
+    /// </summary>
+    [TestMethod]
+    public void Decode_WithInt64RoundTrip_PreservesValues()
+    {
+        // Arrange
+        long[] values = [long.MinValue, -1, 0, 1, 42, long.MaxValue];
+        var outputStream = new XdrDataOutputStream();
+        foreach (var value in values)
+        {
+            Int64.Encode(outputStream, new Int64(value));
+        }
+        var inputStream = new XdrDataInputStream(outputStream.ToArray());
+
+        // Act & Assert
+        foreach (var value in values)
+        {
+            Assert.AreEqual(value, Int64.Decode(inputStream).InnerValue);
+        }
+    }
+
+    /// <summary>
+    ///     Verifies that XDR ulong values round-trip correctly through the data streams.
+    /// </summary>
+    [TestMethod]
+    public void Decode_WithUint64RoundTrip_PreservesValues()
+    {
+        // Arrange
+        ulong[] values = [ulong.MinValue, 1, 42, 0x8000000000000000, ulong.MaxValue];
+        var outputStream = new XdrDataOutputStream();
+        foreach (var value in values)
+        {
+            Uint64.Encode(outputStream, new Uint64(value));
+        }
+        var inputStream = new XdrDataInputStream(outputStream.ToArray());
+
+        // Act & Assert
+        foreach (var value in values)
+        {
+            Assert.AreEqual(value, Uint64.Decode(inputStream).InnerValue);
+        }
+    }
+
+    /// <summary>
+    ///     Verifies that reading a single byte past the end of the input throws EndOfStreamException.
+    /// </summary>
+    [TestMethod]
+    public void Read_PastEndOfInput_ThrowsEndOfStreamException()
+    {
+        // Arrange
+        var inputStream = new XdrDataInputStream([]);
+
+        // Act & Assert
+        Assert.ThrowsException<EndOfStreamException>(() => inputStream.Read());
+    }
+
+    /// <summary>
+    ///     Verifies that reading an int from truncated input throws EndOfStreamException instead of
+    ///     returning a partially read value.
+    /// </summary>
+    [TestMethod]
+    public void ReadInt_WithTruncatedInput_ThrowsEndOfStreamException()
+    {
+        // Arrange
+        var inputStream = new XdrDataInputStream([0, 1]);
+
+        // Act & Assert
+        Assert.ThrowsException<EndOfStreamException>(() => inputStream.ReadInt());
+    }
+
+    /// <summary>
+    ///     Verifies that decoding a long from truncated input throws EndOfStreamException instead of
+    ///     returning a partially read value.
+    /// </summary>
+    [TestMethod]
+    public void Decode_WithTruncatedInt64_ThrowsEndOfStreamException()
+    {
+        // Arrange
+        var inputStream = new XdrDataInputStream([0, 1, 2, 3]);
+
+        // Act & Assert
+        Assert.ThrowsException<EndOfStreamException>(() => Int64.Decode(inputStream));
+    }
+
+    /// <summary>
+    ///     Verifies that reading a fixed-length opaque array from truncated input throws InvalidDataException.
+    /// </summary>
+    [TestMethod]
+    public void Read_WithTruncatedFixedLengthOpaqueArray_ThrowsInvalidDataException()
+    {
+        // Arrange
+        var inputStream = new XdrDataInputStream([1, 2, 3]);
+        var buffer = new byte[5];
+
+        // Act & Assert
+        Assert.ThrowsException<InvalidDataException>(() => inputStream.Read(buffer, 0, 5));
+    }
+
+    /// <summary>
+    ///     Verifies that reading a string with a truncated length prefix throws FormatException.
+    /// </summary>
+    [TestMethod]
+    public void ReadString_WithTruncatedLengthPrefix_ThrowsFormatException()
+    {
+        // Arrange
+        var inputStream = new XdrDataInputStream([0, 0]);
+
+        // Act & Assert
+        Assert.ThrowsException<FormatException>(() => inputStream.ReadString());
+    }
+
+    /// <summary>
+    ///     Verifies that XDR float values round-trip bit-exactly through the data streams,
+    ///     including signed zeros, infinities, and NaN.
+    /// </summary>
+    [TestMethod]
+    public void ReadSingle_WithRoundTrip_PreservesBitPatterns()
+    {
+        // Arrange
+        float[] values =
+        [
+            float.MinValue, -1.5f, -0f, 0f, float.Epsilon, 1.5f, float.MaxValue,
+            float.PositiveInfinity, float.NegativeInfinity, float.NaN,
+        ];
+        var outputStream = new XdrDataOutputStream();
+        foreach (var value in values)
+        {
+            outputStream.WriteSingle(value);
+        }
+        var inputStream = new XdrDataInputStream(outputStream.ToArray());
+
+        // Act & Assert
+        foreach (var value in values)
+        {
+            Assert.AreEqual(
+                BitConverter.SingleToInt32Bits(value),
+                BitConverter.SingleToInt32Bits(inputStream.ReadSingle()));
+        }
+    }
+
+    /// <summary>
+    ///     Verifies that XDR double values round-trip bit-exactly through the data streams,
+    ///     including signed zeros, infinities, and NaN.
+    /// </summary>
+    [TestMethod]
+    public void ReadDouble_WithRoundTrip_PreservesBitPatterns()
+    {
+        // Arrange
+        double[] values =
+        [
+            double.MinValue, -1.5, -0d, 0d, double.Epsilon, 1.5, double.MaxValue,
+            double.PositiveInfinity, double.NegativeInfinity, double.NaN,
+        ];
+        var outputStream = new XdrDataOutputStream();
+        foreach (var value in values)
+        {
+            outputStream.WriteDouble(value);
+        }
+        var inputStream = new XdrDataInputStream(outputStream.ToArray());
+
+        // Act & Assert
+        foreach (var value in values)
+        {
+            Assert.AreEqual(
+                BitConverter.DoubleToInt64Bits(value),
+                BitConverter.DoubleToInt64Bits(inputStream.ReadDouble()));
+        }
+    }
+
+    /// <summary>
+    ///     Verifies that reading a string whose length prefix is intact but whose body is truncated
+    ///     throws InvalidDataException.
+    /// </summary>
+    [TestMethod]
+    public void ReadString_WithTruncatedBody_ThrowsInvalidDataException()
+    {
+        // Arrange
+        var inputStream = new XdrDataInputStream([0, 0, 0, 5, 1, 2]);
+
+        // Act & Assert
+        Assert.ThrowsException<InvalidDataException>(() => inputStream.ReadString());
+    }
+
+    /// <summary>
+    ///     Verifies that reading a variable-length opaque whose length prefix is intact but whose body
+    ///     is truncated throws InvalidDataException.
+    /// </summary>
+    [TestMethod]
+    public void ReadVarOpaque_WithTruncatedBody_ThrowsInvalidDataException()
+    {
+        // Arrange
+        var inputStream = new XdrDataInputStream([0, 0, 0, 5, 1, 2]);
+
+        // Act & Assert
+        Assert.ThrowsException<InvalidDataException>(() => inputStream.ReadVarOpaque(10));
     }
 }

--- a/StellarDotnetSdk.Tests/Xdr/XdrDataStreamTest.cs
+++ b/StellarDotnetSdk.Tests/Xdr/XdrDataStreamTest.cs
@@ -186,6 +186,17 @@ public class XdrDataStreamTest
     }
 
     /// <summary>
+    ///     Verifies that constructing the stream with a null buffer throws ArgumentNullException up front,
+    ///     since a null buffer is not a supported input.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WithNullBuffer_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.ThrowsException<ArgumentNullException>(() => new XdrDataInputStream(null!));
+    }
+
+    /// <summary>
     ///     Verifies that reading a single byte past the end of the input throws EndOfStreamException.
     /// </summary>
     [TestMethod]

--- a/StellarDotnetSdk.Xdr/StellarDotnetSdk.Xdr.csproj
+++ b/StellarDotnetSdk.Xdr/StellarDotnetSdk.Xdr.csproj
@@ -17,7 +17,6 @@
         <ReleaseNotes>https://github.com/Beans-BV/dotnet-stellar-sdk/releases</ReleaseNotes>
         <WarningLevel>0</WarningLevel>
         <IsPackable>true</IsPackable>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Nullable>disable</Nullable>
         <RootNamespace>StellarDotnetSdk.Xdr</RootNamespace>
         <LangVersion>12</LangVersion>

--- a/StellarDotnetSdk.Xdr/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/XdrDataInputStream.cs
@@ -25,11 +25,9 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
+        ArgumentNullException.ThrowIfNull(bytes);
         _bytes = bytes;
-        if (bytes != null)
-        {
-            _stream = new MemoryStream(bytes, false);
-        }
+        _stream = new MemoryStream(bytes, false);
     }
 
     /// <summary>
@@ -185,7 +183,6 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_stream == null) return -1;
         return (int)(_stream.Length - _stream.Position);
     }
 

--- a/StellarDotnetSdk.Xdr/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/XdrDataInputStream.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -16,7 +17,7 @@ public class XdrDataInputStream
     public const int DefaultMaxDepth = 200;
 
     private readonly byte[] _bytes;
-    private int _pos;
+    private readonly MemoryStream _stream;
 
     /// <summary>
     ///     Create the stream from a byte array.
@@ -25,6 +26,10 @@ public class XdrDataInputStream
     public XdrDataInputStream(byte[] bytes)
     {
         _bytes = bytes;
+        if (bytes != null)
+        {
+            _stream = new MemoryStream(bytes, false);
+        }
     }
 
     /// <summary>
@@ -33,10 +38,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public byte Read()
     {
-        var res = _bytes[_pos];
-        _pos++;
-
-        return res;
+        Span<byte> buffer = stackalloc byte[1];
+        _stream.ReadExactly(buffer);
+        return buffer[0];
     }
 
     /// <summary>
@@ -82,28 +86,16 @@ public class XdrDataInputStream
 
     internal long ReadLong()
     {
-        return
-            ((long)_bytes[_pos++] << 56) |
-            ((long)_bytes[_pos++] << 48) |
-            ((long)_bytes[_pos++] << 40) |
-            ((long)_bytes[_pos++] << 32) |
-            ((long)_bytes[_pos++] << 24) |
-            ((long)_bytes[_pos++] << 16) |
-            ((long)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
-        return
-            ((ulong)_bytes[_pos++] << 56) |
-            ((ulong)_bytes[_pos++] << 48) |
-            ((ulong)_bytes[_pos++] << 40) |
-            ((ulong)_bytes[_pos++] << 32) |
-            ((ulong)_bytes[_pos++] << 24) |
-            ((ulong)_bytes[_pos++] << 16) |
-            ((ulong)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
     /// <summary>
@@ -112,11 +104,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public int ReadInt()
     {
-        return
-            (_bytes[_pos++] << 0x18) |
-            (_bytes[_pos++] << 0x10) |
-            (_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
     /// <summary>
@@ -125,17 +115,14 @@ public class XdrDataInputStream
     /// <returns></returns>
     public uint ReadUInt()
     {
-        return
-            ((uint)_bytes[_pos++] << 0x18) |
-            ((uint)_bytes[_pos++] << 0x10) |
-            ((uint)_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
-    public unsafe float ReadSingle()
+    public float ReadSingle()
     {
-        var num = ReadInt();
-        return *(float*)&num;
+        return BitConverter.Int32BitsToSingle(ReadInt());
     }
 
     /// <summary>
@@ -159,10 +146,9 @@ public class XdrDataInputStream
         return arr;
     }
 
-    public unsafe double ReadDouble()
+    public double ReadDouble()
     {
-        var num = ReadLong();
-        return *(double*)&num;
+        return BitConverter.Int64BitsToDouble(ReadLong());
     }
 
     /// <summary>
@@ -199,8 +185,8 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_bytes == null) return -1;
-        return _bytes.Length - _pos;
+        if (_stream == null) return -1;
+        return (int)(_stream.Length - _stream.Position);
     }
 
     /// <summary>
@@ -238,24 +224,20 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        Array.Copy(_bytes, _pos, result, 0, (int)len);
+        _stream.ReadExactly(result);
 
         if (tail == 0)
         {
-            _pos += (int)len;
             return result;
         }
 
         var tailBytes = new byte[tailLength];
-
-        Array.Copy(_bytes, _pos + len, tailBytes, 0, tailLength);
+        _stream.ReadExactly(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {
             throw new IOException("non-zero padding");
         }
-
-        _pos += (int)len + tailLength;
 
         return result;
     }

--- a/StellarDotnetSdk.Xdr/XdrDataOutputStream.cs
+++ b/StellarDotnetSdk.Xdr/XdrDataOutputStream.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
 
@@ -66,47 +67,35 @@ public class XdrDataOutputStream
 
     public void WriteLong(long v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        BinaryPrimitives.WriteInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteULong(ulong v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteInt(int i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteUInt(uint i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
-    public unsafe void WriteSingle(float v)
+    public void WriteSingle(float v)
     {
-        WriteInt(*(int*)&v);
+        WriteInt(BitConverter.SingleToInt32Bits(v));
     }
 
     public void WriteSingleArray(float[] a)
@@ -123,9 +112,9 @@ public class XdrDataOutputStream
         }
     }
 
-    public unsafe void WriteDouble(double v)
+    public void WriteDouble(double v)
     {
-        WriteLong(*(long*)&v);
+        WriteLong(BitConverter.DoubleToInt64Bits(v));
     }
 
     public void WriteDoubleArray(double[] a)

--- a/StellarDotnetSdk.Xdr/xdr-generator/generator/templates/XdrDataInputStream.erb
+++ b/StellarDotnetSdk.Xdr/xdr-generator/generator/templates/XdrDataInputStream.erb
@@ -25,11 +25,9 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
+        ArgumentNullException.ThrowIfNull(bytes);
         _bytes = bytes;
-        if (bytes != null)
-        {
-            _stream = new MemoryStream(bytes, false);
-        }
+        _stream = new MemoryStream(bytes, false);
     }
 
     /// <summary>
@@ -185,7 +183,6 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_stream == null) return -1;
         return (int)(_stream.Length - _stream.Position);
     }
 

--- a/StellarDotnetSdk.Xdr/xdr-generator/generator/templates/XdrDataInputStream.erb
+++ b/StellarDotnetSdk.Xdr/xdr-generator/generator/templates/XdrDataInputStream.erb
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -16,7 +17,7 @@ public class XdrDataInputStream
     public const int DefaultMaxDepth = 200;
 
     private readonly byte[] _bytes;
-    private int _pos;
+    private readonly MemoryStream _stream;
 
     /// <summary>
     ///     Create the stream from a byte array.
@@ -25,6 +26,10 @@ public class XdrDataInputStream
     public XdrDataInputStream(byte[] bytes)
     {
         _bytes = bytes;
+        if (bytes != null)
+        {
+            _stream = new MemoryStream(bytes, false);
+        }
     }
 
     /// <summary>
@@ -33,10 +38,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public byte Read()
     {
-        var res = _bytes[_pos];
-        _pos++;
-
-        return res;
+        Span<byte> buffer = stackalloc byte[1];
+        _stream.ReadExactly(buffer);
+        return buffer[0];
     }
 
     /// <summary>
@@ -82,28 +86,16 @@ public class XdrDataInputStream
 
     internal long ReadLong()
     {
-        return
-            ((long)_bytes[_pos++] << 56) |
-            ((long)_bytes[_pos++] << 48) |
-            ((long)_bytes[_pos++] << 40) |
-            ((long)_bytes[_pos++] << 32) |
-            ((long)_bytes[_pos++] << 24) |
-            ((long)_bytes[_pos++] << 16) |
-            ((long)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
-        return
-            ((ulong)_bytes[_pos++] << 56) |
-            ((ulong)_bytes[_pos++] << 48) |
-            ((ulong)_bytes[_pos++] << 40) |
-            ((ulong)_bytes[_pos++] << 32) |
-            ((ulong)_bytes[_pos++] << 24) |
-            ((ulong)_bytes[_pos++] << 16) |
-            ((ulong)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
     /// <summary>
@@ -112,11 +104,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public int ReadInt()
     {
-        return
-            (_bytes[_pos++] << 0x18) |
-            (_bytes[_pos++] << 0x10) |
-            (_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
     /// <summary>
@@ -125,17 +115,14 @@ public class XdrDataInputStream
     /// <returns></returns>
     public uint ReadUInt()
     {
-        return
-            ((uint)_bytes[_pos++] << 0x18) |
-            ((uint)_bytes[_pos++] << 0x10) |
-            ((uint)_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
-    public unsafe float ReadSingle()
+    public float ReadSingle()
     {
-        var num = ReadInt();
-        return *(float*)&num;
+        return BitConverter.Int32BitsToSingle(ReadInt());
     }
 
     /// <summary>
@@ -159,10 +146,9 @@ public class XdrDataInputStream
         return arr;
     }
 
-    public unsafe double ReadDouble()
+    public double ReadDouble()
     {
-        var num = ReadLong();
-        return *(double*)&num;
+        return BitConverter.Int64BitsToDouble(ReadLong());
     }
 
     /// <summary>
@@ -199,8 +185,8 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_bytes == null) return -1;
-        return _bytes.Length - _pos;
+        if (_stream == null) return -1;
+        return (int)(_stream.Length - _stream.Position);
     }
 
     /// <summary>
@@ -238,24 +224,20 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        Array.Copy(_bytes, _pos, result, 0, (int)len);
+        _stream.ReadExactly(result);
 
         if (tail == 0)
         {
-            _pos += (int)len;
             return result;
         }
 
         var tailBytes = new byte[tailLength];
-
-        Array.Copy(_bytes, _pos + len, tailBytes, 0, tailLength);
+        _stream.ReadExactly(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {
             throw new IOException("non-zero padding");
         }
-
-        _pos += (int)len + tailLength;
 
         return result;
     }

--- a/StellarDotnetSdk.Xdr/xdr-generator/generator/templates/XdrDataOutputStream.erb
+++ b/StellarDotnetSdk.Xdr/xdr-generator/generator/templates/XdrDataOutputStream.erb
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
 
@@ -66,47 +67,35 @@ public class XdrDataOutputStream
 
     public void WriteLong(long v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        BinaryPrimitives.WriteInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteULong(ulong v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteInt(int i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteUInt(uint i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
-    public unsafe void WriteSingle(float v)
+    public void WriteSingle(float v)
     {
-        WriteInt(*(int*)&v);
+        WriteInt(BitConverter.SingleToInt32Bits(v));
     }
 
     public void WriteSingleArray(float[] a)
@@ -123,9 +112,9 @@ public class XdrDataOutputStream
         }
     }
 
-    public unsafe void WriteDouble(double v)
+    public void WriteDouble(double v)
     {
-        WriteLong(*(long*)&v);
+        WriteLong(BitConverter.DoubleToInt64Bits(v));
     }
 
     public void WriteDoubleArray(double[] a)

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/block_comments/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/block_comments/XdrDataInputStream.cs
@@ -25,11 +25,9 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
+        ArgumentNullException.ThrowIfNull(bytes);
         _bytes = bytes;
-        if (bytes != null)
-        {
-            _stream = new MemoryStream(bytes, false);
-        }
+        _stream = new MemoryStream(bytes, false);
     }
 
     /// <summary>
@@ -185,7 +183,6 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_stream == null) return -1;
         return (int)(_stream.Length - _stream.Position);
     }
 

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/block_comments/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/block_comments/XdrDataInputStream.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -16,7 +17,7 @@ public class XdrDataInputStream
     public const int DefaultMaxDepth = 200;
 
     private readonly byte[] _bytes;
-    private int _pos;
+    private readonly MemoryStream _stream;
 
     /// <summary>
     ///     Create the stream from a byte array.
@@ -25,6 +26,10 @@ public class XdrDataInputStream
     public XdrDataInputStream(byte[] bytes)
     {
         _bytes = bytes;
+        if (bytes != null)
+        {
+            _stream = new MemoryStream(bytes, false);
+        }
     }
 
     /// <summary>
@@ -33,10 +38,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public byte Read()
     {
-        var res = _bytes[_pos];
-        _pos++;
-
-        return res;
+        Span<byte> buffer = stackalloc byte[1];
+        _stream.ReadExactly(buffer);
+        return buffer[0];
     }
 
     /// <summary>
@@ -82,28 +86,16 @@ public class XdrDataInputStream
 
     internal long ReadLong()
     {
-        return
-            ((long)_bytes[_pos++] << 56) |
-            ((long)_bytes[_pos++] << 48) |
-            ((long)_bytes[_pos++] << 40) |
-            ((long)_bytes[_pos++] << 32) |
-            ((long)_bytes[_pos++] << 24) |
-            ((long)_bytes[_pos++] << 16) |
-            ((long)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
-        return
-            ((ulong)_bytes[_pos++] << 56) |
-            ((ulong)_bytes[_pos++] << 48) |
-            ((ulong)_bytes[_pos++] << 40) |
-            ((ulong)_bytes[_pos++] << 32) |
-            ((ulong)_bytes[_pos++] << 24) |
-            ((ulong)_bytes[_pos++] << 16) |
-            ((ulong)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
     /// <summary>
@@ -112,11 +104,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public int ReadInt()
     {
-        return
-            (_bytes[_pos++] << 0x18) |
-            (_bytes[_pos++] << 0x10) |
-            (_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
     /// <summary>
@@ -125,17 +115,14 @@ public class XdrDataInputStream
     /// <returns></returns>
     public uint ReadUInt()
     {
-        return
-            ((uint)_bytes[_pos++] << 0x18) |
-            ((uint)_bytes[_pos++] << 0x10) |
-            ((uint)_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
-    public unsafe float ReadSingle()
+    public float ReadSingle()
     {
-        var num = ReadInt();
-        return *(float*)&num;
+        return BitConverter.Int32BitsToSingle(ReadInt());
     }
 
     /// <summary>
@@ -159,10 +146,9 @@ public class XdrDataInputStream
         return arr;
     }
 
-    public unsafe double ReadDouble()
+    public double ReadDouble()
     {
-        var num = ReadLong();
-        return *(double*)&num;
+        return BitConverter.Int64BitsToDouble(ReadLong());
     }
 
     /// <summary>
@@ -199,8 +185,8 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_bytes == null) return -1;
-        return _bytes.Length - _pos;
+        if (_stream == null) return -1;
+        return (int)(_stream.Length - _stream.Position);
     }
 
     /// <summary>
@@ -238,24 +224,20 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        Array.Copy(_bytes, _pos, result, 0, (int)len);
+        _stream.ReadExactly(result);
 
         if (tail == 0)
         {
-            _pos += (int)len;
             return result;
         }
 
         var tailBytes = new byte[tailLength];
-
-        Array.Copy(_bytes, _pos + len, tailBytes, 0, tailLength);
+        _stream.ReadExactly(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {
             throw new IOException("non-zero padding");
         }
-
-        _pos += (int)len + tailLength;
 
         return result;
     }

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/block_comments/XdrDataOutputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/block_comments/XdrDataOutputStream.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
 
@@ -66,47 +67,35 @@ public class XdrDataOutputStream
 
     public void WriteLong(long v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        BinaryPrimitives.WriteInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteULong(ulong v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteInt(int i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteUInt(uint i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
-    public unsafe void WriteSingle(float v)
+    public void WriteSingle(float v)
     {
-        WriteInt(*(int*)&v);
+        WriteInt(BitConverter.SingleToInt32Bits(v));
     }
 
     public void WriteSingleArray(float[] a)
@@ -123,9 +112,9 @@ public class XdrDataOutputStream
         }
     }
 
-    public unsafe void WriteDouble(double v)
+    public void WriteDouble(double v)
     {
-        WriteLong(*(long*)&v);
+        WriteLong(BitConverter.DoubleToInt64Bits(v));
     }
 
     public void WriteDoubleArray(double[] a)

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/const/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/const/XdrDataInputStream.cs
@@ -25,11 +25,9 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
+        ArgumentNullException.ThrowIfNull(bytes);
         _bytes = bytes;
-        if (bytes != null)
-        {
-            _stream = new MemoryStream(bytes, false);
-        }
+        _stream = new MemoryStream(bytes, false);
     }
 
     /// <summary>
@@ -185,7 +183,6 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_stream == null) return -1;
         return (int)(_stream.Length - _stream.Position);
     }
 

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/const/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/const/XdrDataInputStream.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -16,7 +17,7 @@ public class XdrDataInputStream
     public const int DefaultMaxDepth = 200;
 
     private readonly byte[] _bytes;
-    private int _pos;
+    private readonly MemoryStream _stream;
 
     /// <summary>
     ///     Create the stream from a byte array.
@@ -25,6 +26,10 @@ public class XdrDataInputStream
     public XdrDataInputStream(byte[] bytes)
     {
         _bytes = bytes;
+        if (bytes != null)
+        {
+            _stream = new MemoryStream(bytes, false);
+        }
     }
 
     /// <summary>
@@ -33,10 +38,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public byte Read()
     {
-        var res = _bytes[_pos];
-        _pos++;
-
-        return res;
+        Span<byte> buffer = stackalloc byte[1];
+        _stream.ReadExactly(buffer);
+        return buffer[0];
     }
 
     /// <summary>
@@ -82,28 +86,16 @@ public class XdrDataInputStream
 
     internal long ReadLong()
     {
-        return
-            ((long)_bytes[_pos++] << 56) |
-            ((long)_bytes[_pos++] << 48) |
-            ((long)_bytes[_pos++] << 40) |
-            ((long)_bytes[_pos++] << 32) |
-            ((long)_bytes[_pos++] << 24) |
-            ((long)_bytes[_pos++] << 16) |
-            ((long)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
-        return
-            ((ulong)_bytes[_pos++] << 56) |
-            ((ulong)_bytes[_pos++] << 48) |
-            ((ulong)_bytes[_pos++] << 40) |
-            ((ulong)_bytes[_pos++] << 32) |
-            ((ulong)_bytes[_pos++] << 24) |
-            ((ulong)_bytes[_pos++] << 16) |
-            ((ulong)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
     /// <summary>
@@ -112,11 +104,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public int ReadInt()
     {
-        return
-            (_bytes[_pos++] << 0x18) |
-            (_bytes[_pos++] << 0x10) |
-            (_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
     /// <summary>
@@ -125,17 +115,14 @@ public class XdrDataInputStream
     /// <returns></returns>
     public uint ReadUInt()
     {
-        return
-            ((uint)_bytes[_pos++] << 0x18) |
-            ((uint)_bytes[_pos++] << 0x10) |
-            ((uint)_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
-    public unsafe float ReadSingle()
+    public float ReadSingle()
     {
-        var num = ReadInt();
-        return *(float*)&num;
+        return BitConverter.Int32BitsToSingle(ReadInt());
     }
 
     /// <summary>
@@ -159,10 +146,9 @@ public class XdrDataInputStream
         return arr;
     }
 
-    public unsafe double ReadDouble()
+    public double ReadDouble()
     {
-        var num = ReadLong();
-        return *(double*)&num;
+        return BitConverter.Int64BitsToDouble(ReadLong());
     }
 
     /// <summary>
@@ -199,8 +185,8 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_bytes == null) return -1;
-        return _bytes.Length - _pos;
+        if (_stream == null) return -1;
+        return (int)(_stream.Length - _stream.Position);
     }
 
     /// <summary>
@@ -238,24 +224,20 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        Array.Copy(_bytes, _pos, result, 0, (int)len);
+        _stream.ReadExactly(result);
 
         if (tail == 0)
         {
-            _pos += (int)len;
             return result;
         }
 
         var tailBytes = new byte[tailLength];
-
-        Array.Copy(_bytes, _pos + len, tailBytes, 0, tailLength);
+        _stream.ReadExactly(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {
             throw new IOException("non-zero padding");
         }
-
-        _pos += (int)len + tailLength;
 
         return result;
     }

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/const/XdrDataOutputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/const/XdrDataOutputStream.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
 
@@ -66,47 +67,35 @@ public class XdrDataOutputStream
 
     public void WriteLong(long v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        BinaryPrimitives.WriteInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteULong(ulong v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteInt(int i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteUInt(uint i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
-    public unsafe void WriteSingle(float v)
+    public void WriteSingle(float v)
     {
-        WriteInt(*(int*)&v);
+        WriteInt(BitConverter.SingleToInt32Bits(v));
     }
 
     public void WriteSingleArray(float[] a)
@@ -123,9 +112,9 @@ public class XdrDataOutputStream
         }
     }
 
-    public unsafe void WriteDouble(double v)
+    public void WriteDouble(double v)
     {
-        WriteLong(*(long*)&v);
+        WriteLong(BitConverter.DoubleToInt64Bits(v));
     }
 
     public void WriteDoubleArray(double[] a)

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/enum/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/enum/XdrDataInputStream.cs
@@ -25,11 +25,9 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
+        ArgumentNullException.ThrowIfNull(bytes);
         _bytes = bytes;
-        if (bytes != null)
-        {
-            _stream = new MemoryStream(bytes, false);
-        }
+        _stream = new MemoryStream(bytes, false);
     }
 
     /// <summary>
@@ -185,7 +183,6 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_stream == null) return -1;
         return (int)(_stream.Length - _stream.Position);
     }
 

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/enum/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/enum/XdrDataInputStream.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -16,7 +17,7 @@ public class XdrDataInputStream
     public const int DefaultMaxDepth = 200;
 
     private readonly byte[] _bytes;
-    private int _pos;
+    private readonly MemoryStream _stream;
 
     /// <summary>
     ///     Create the stream from a byte array.
@@ -25,6 +26,10 @@ public class XdrDataInputStream
     public XdrDataInputStream(byte[] bytes)
     {
         _bytes = bytes;
+        if (bytes != null)
+        {
+            _stream = new MemoryStream(bytes, false);
+        }
     }
 
     /// <summary>
@@ -33,10 +38,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public byte Read()
     {
-        var res = _bytes[_pos];
-        _pos++;
-
-        return res;
+        Span<byte> buffer = stackalloc byte[1];
+        _stream.ReadExactly(buffer);
+        return buffer[0];
     }
 
     /// <summary>
@@ -82,28 +86,16 @@ public class XdrDataInputStream
 
     internal long ReadLong()
     {
-        return
-            ((long)_bytes[_pos++] << 56) |
-            ((long)_bytes[_pos++] << 48) |
-            ((long)_bytes[_pos++] << 40) |
-            ((long)_bytes[_pos++] << 32) |
-            ((long)_bytes[_pos++] << 24) |
-            ((long)_bytes[_pos++] << 16) |
-            ((long)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
-        return
-            ((ulong)_bytes[_pos++] << 56) |
-            ((ulong)_bytes[_pos++] << 48) |
-            ((ulong)_bytes[_pos++] << 40) |
-            ((ulong)_bytes[_pos++] << 32) |
-            ((ulong)_bytes[_pos++] << 24) |
-            ((ulong)_bytes[_pos++] << 16) |
-            ((ulong)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
     /// <summary>
@@ -112,11 +104,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public int ReadInt()
     {
-        return
-            (_bytes[_pos++] << 0x18) |
-            (_bytes[_pos++] << 0x10) |
-            (_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
     /// <summary>
@@ -125,17 +115,14 @@ public class XdrDataInputStream
     /// <returns></returns>
     public uint ReadUInt()
     {
-        return
-            ((uint)_bytes[_pos++] << 0x18) |
-            ((uint)_bytes[_pos++] << 0x10) |
-            ((uint)_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
-    public unsafe float ReadSingle()
+    public float ReadSingle()
     {
-        var num = ReadInt();
-        return *(float*)&num;
+        return BitConverter.Int32BitsToSingle(ReadInt());
     }
 
     /// <summary>
@@ -159,10 +146,9 @@ public class XdrDataInputStream
         return arr;
     }
 
-    public unsafe double ReadDouble()
+    public double ReadDouble()
     {
-        var num = ReadLong();
-        return *(double*)&num;
+        return BitConverter.Int64BitsToDouble(ReadLong());
     }
 
     /// <summary>
@@ -199,8 +185,8 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_bytes == null) return -1;
-        return _bytes.Length - _pos;
+        if (_stream == null) return -1;
+        return (int)(_stream.Length - _stream.Position);
     }
 
     /// <summary>
@@ -238,24 +224,20 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        Array.Copy(_bytes, _pos, result, 0, (int)len);
+        _stream.ReadExactly(result);
 
         if (tail == 0)
         {
-            _pos += (int)len;
             return result;
         }
 
         var tailBytes = new byte[tailLength];
-
-        Array.Copy(_bytes, _pos + len, tailBytes, 0, tailLength);
+        _stream.ReadExactly(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {
             throw new IOException("non-zero padding");
         }
-
-        _pos += (int)len + tailLength;
 
         return result;
     }

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/enum/XdrDataOutputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/enum/XdrDataOutputStream.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
 
@@ -66,47 +67,35 @@ public class XdrDataOutputStream
 
     public void WriteLong(long v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        BinaryPrimitives.WriteInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteULong(ulong v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteInt(int i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteUInt(uint i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
-    public unsafe void WriteSingle(float v)
+    public void WriteSingle(float v)
     {
-        WriteInt(*(int*)&v);
+        WriteInt(BitConverter.SingleToInt32Bits(v));
     }
 
     public void WriteSingleArray(float[] a)
@@ -123,9 +112,9 @@ public class XdrDataOutputStream
         }
     }
 
-    public unsafe void WriteDouble(double v)
+    public void WriteDouble(double v)
     {
-        WriteLong(*(long*)&v);
+        WriteLong(BitConverter.DoubleToInt64Bits(v));
     }
 
     public void WriteDoubleArray(double[] a)

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/nesting/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/nesting/XdrDataInputStream.cs
@@ -25,11 +25,9 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
+        ArgumentNullException.ThrowIfNull(bytes);
         _bytes = bytes;
-        if (bytes != null)
-        {
-            _stream = new MemoryStream(bytes, false);
-        }
+        _stream = new MemoryStream(bytes, false);
     }
 
     /// <summary>
@@ -185,7 +183,6 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_stream == null) return -1;
         return (int)(_stream.Length - _stream.Position);
     }
 

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/nesting/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/nesting/XdrDataInputStream.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -16,7 +17,7 @@ public class XdrDataInputStream
     public const int DefaultMaxDepth = 200;
 
     private readonly byte[] _bytes;
-    private int _pos;
+    private readonly MemoryStream _stream;
 
     /// <summary>
     ///     Create the stream from a byte array.
@@ -25,6 +26,10 @@ public class XdrDataInputStream
     public XdrDataInputStream(byte[] bytes)
     {
         _bytes = bytes;
+        if (bytes != null)
+        {
+            _stream = new MemoryStream(bytes, false);
+        }
     }
 
     /// <summary>
@@ -33,10 +38,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public byte Read()
     {
-        var res = _bytes[_pos];
-        _pos++;
-
-        return res;
+        Span<byte> buffer = stackalloc byte[1];
+        _stream.ReadExactly(buffer);
+        return buffer[0];
     }
 
     /// <summary>
@@ -82,28 +86,16 @@ public class XdrDataInputStream
 
     internal long ReadLong()
     {
-        return
-            ((long)_bytes[_pos++] << 56) |
-            ((long)_bytes[_pos++] << 48) |
-            ((long)_bytes[_pos++] << 40) |
-            ((long)_bytes[_pos++] << 32) |
-            ((long)_bytes[_pos++] << 24) |
-            ((long)_bytes[_pos++] << 16) |
-            ((long)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
-        return
-            ((ulong)_bytes[_pos++] << 56) |
-            ((ulong)_bytes[_pos++] << 48) |
-            ((ulong)_bytes[_pos++] << 40) |
-            ((ulong)_bytes[_pos++] << 32) |
-            ((ulong)_bytes[_pos++] << 24) |
-            ((ulong)_bytes[_pos++] << 16) |
-            ((ulong)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
     /// <summary>
@@ -112,11 +104,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public int ReadInt()
     {
-        return
-            (_bytes[_pos++] << 0x18) |
-            (_bytes[_pos++] << 0x10) |
-            (_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
     /// <summary>
@@ -125,17 +115,14 @@ public class XdrDataInputStream
     /// <returns></returns>
     public uint ReadUInt()
     {
-        return
-            ((uint)_bytes[_pos++] << 0x18) |
-            ((uint)_bytes[_pos++] << 0x10) |
-            ((uint)_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
-    public unsafe float ReadSingle()
+    public float ReadSingle()
     {
-        var num = ReadInt();
-        return *(float*)&num;
+        return BitConverter.Int32BitsToSingle(ReadInt());
     }
 
     /// <summary>
@@ -159,10 +146,9 @@ public class XdrDataInputStream
         return arr;
     }
 
-    public unsafe double ReadDouble()
+    public double ReadDouble()
     {
-        var num = ReadLong();
-        return *(double*)&num;
+        return BitConverter.Int64BitsToDouble(ReadLong());
     }
 
     /// <summary>
@@ -199,8 +185,8 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_bytes == null) return -1;
-        return _bytes.Length - _pos;
+        if (_stream == null) return -1;
+        return (int)(_stream.Length - _stream.Position);
     }
 
     /// <summary>
@@ -238,24 +224,20 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        Array.Copy(_bytes, _pos, result, 0, (int)len);
+        _stream.ReadExactly(result);
 
         if (tail == 0)
         {
-            _pos += (int)len;
             return result;
         }
 
         var tailBytes = new byte[tailLength];
-
-        Array.Copy(_bytes, _pos + len, tailBytes, 0, tailLength);
+        _stream.ReadExactly(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {
             throw new IOException("non-zero padding");
         }
-
-        _pos += (int)len + tailLength;
 
         return result;
     }

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/nesting/XdrDataOutputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/nesting/XdrDataOutputStream.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
 
@@ -66,47 +67,35 @@ public class XdrDataOutputStream
 
     public void WriteLong(long v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        BinaryPrimitives.WriteInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteULong(ulong v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteInt(int i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteUInt(uint i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
-    public unsafe void WriteSingle(float v)
+    public void WriteSingle(float v)
     {
-        WriteInt(*(int*)&v);
+        WriteInt(BitConverter.SingleToInt32Bits(v));
     }
 
     public void WriteSingleArray(float[] a)
@@ -123,9 +112,9 @@ public class XdrDataOutputStream
         }
     }
 
-    public unsafe void WriteDouble(double v)
+    public void WriteDouble(double v)
     {
-        WriteLong(*(long*)&v);
+        WriteLong(BitConverter.DoubleToInt64Bits(v));
     }
 
     public void WriteDoubleArray(double[] a)

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/optional/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/optional/XdrDataInputStream.cs
@@ -25,11 +25,9 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
+        ArgumentNullException.ThrowIfNull(bytes);
         _bytes = bytes;
-        if (bytes != null)
-        {
-            _stream = new MemoryStream(bytes, false);
-        }
+        _stream = new MemoryStream(bytes, false);
     }
 
     /// <summary>
@@ -185,7 +183,6 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_stream == null) return -1;
         return (int)(_stream.Length - _stream.Position);
     }
 

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/optional/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/optional/XdrDataInputStream.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -16,7 +17,7 @@ public class XdrDataInputStream
     public const int DefaultMaxDepth = 200;
 
     private readonly byte[] _bytes;
-    private int _pos;
+    private readonly MemoryStream _stream;
 
     /// <summary>
     ///     Create the stream from a byte array.
@@ -25,6 +26,10 @@ public class XdrDataInputStream
     public XdrDataInputStream(byte[] bytes)
     {
         _bytes = bytes;
+        if (bytes != null)
+        {
+            _stream = new MemoryStream(bytes, false);
+        }
     }
 
     /// <summary>
@@ -33,10 +38,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public byte Read()
     {
-        var res = _bytes[_pos];
-        _pos++;
-
-        return res;
+        Span<byte> buffer = stackalloc byte[1];
+        _stream.ReadExactly(buffer);
+        return buffer[0];
     }
 
     /// <summary>
@@ -82,28 +86,16 @@ public class XdrDataInputStream
 
     internal long ReadLong()
     {
-        return
-            ((long)_bytes[_pos++] << 56) |
-            ((long)_bytes[_pos++] << 48) |
-            ((long)_bytes[_pos++] << 40) |
-            ((long)_bytes[_pos++] << 32) |
-            ((long)_bytes[_pos++] << 24) |
-            ((long)_bytes[_pos++] << 16) |
-            ((long)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
-        return
-            ((ulong)_bytes[_pos++] << 56) |
-            ((ulong)_bytes[_pos++] << 48) |
-            ((ulong)_bytes[_pos++] << 40) |
-            ((ulong)_bytes[_pos++] << 32) |
-            ((ulong)_bytes[_pos++] << 24) |
-            ((ulong)_bytes[_pos++] << 16) |
-            ((ulong)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
     /// <summary>
@@ -112,11 +104,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public int ReadInt()
     {
-        return
-            (_bytes[_pos++] << 0x18) |
-            (_bytes[_pos++] << 0x10) |
-            (_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
     /// <summary>
@@ -125,17 +115,14 @@ public class XdrDataInputStream
     /// <returns></returns>
     public uint ReadUInt()
     {
-        return
-            ((uint)_bytes[_pos++] << 0x18) |
-            ((uint)_bytes[_pos++] << 0x10) |
-            ((uint)_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
-    public unsafe float ReadSingle()
+    public float ReadSingle()
     {
-        var num = ReadInt();
-        return *(float*)&num;
+        return BitConverter.Int32BitsToSingle(ReadInt());
     }
 
     /// <summary>
@@ -159,10 +146,9 @@ public class XdrDataInputStream
         return arr;
     }
 
-    public unsafe double ReadDouble()
+    public double ReadDouble()
     {
-        var num = ReadLong();
-        return *(double*)&num;
+        return BitConverter.Int64BitsToDouble(ReadLong());
     }
 
     /// <summary>
@@ -199,8 +185,8 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_bytes == null) return -1;
-        return _bytes.Length - _pos;
+        if (_stream == null) return -1;
+        return (int)(_stream.Length - _stream.Position);
     }
 
     /// <summary>
@@ -238,24 +224,20 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        Array.Copy(_bytes, _pos, result, 0, (int)len);
+        _stream.ReadExactly(result);
 
         if (tail == 0)
         {
-            _pos += (int)len;
             return result;
         }
 
         var tailBytes = new byte[tailLength];
-
-        Array.Copy(_bytes, _pos + len, tailBytes, 0, tailLength);
+        _stream.ReadExactly(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {
             throw new IOException("non-zero padding");
         }
-
-        _pos += (int)len + tailLength;
 
         return result;
     }

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/optional/XdrDataOutputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/optional/XdrDataOutputStream.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
 
@@ -66,47 +67,35 @@ public class XdrDataOutputStream
 
     public void WriteLong(long v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        BinaryPrimitives.WriteInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteULong(ulong v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteInt(int i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteUInt(uint i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
-    public unsafe void WriteSingle(float v)
+    public void WriteSingle(float v)
     {
-        WriteInt(*(int*)&v);
+        WriteInt(BitConverter.SingleToInt32Bits(v));
     }
 
     public void WriteSingleArray(float[] a)
@@ -123,9 +112,9 @@ public class XdrDataOutputStream
         }
     }
 
-    public unsafe void WriteDouble(double v)
+    public void WriteDouble(double v)
     {
-        WriteLong(*(long*)&v);
+        WriteLong(BitConverter.DoubleToInt64Bits(v));
     }
 
     public void WriteDoubleArray(double[] a)

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/struct/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/struct/XdrDataInputStream.cs
@@ -25,11 +25,9 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
+        ArgumentNullException.ThrowIfNull(bytes);
         _bytes = bytes;
-        if (bytes != null)
-        {
-            _stream = new MemoryStream(bytes, false);
-        }
+        _stream = new MemoryStream(bytes, false);
     }
 
     /// <summary>
@@ -185,7 +183,6 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_stream == null) return -1;
         return (int)(_stream.Length - _stream.Position);
     }
 

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/struct/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/struct/XdrDataInputStream.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -16,7 +17,7 @@ public class XdrDataInputStream
     public const int DefaultMaxDepth = 200;
 
     private readonly byte[] _bytes;
-    private int _pos;
+    private readonly MemoryStream _stream;
 
     /// <summary>
     ///     Create the stream from a byte array.
@@ -25,6 +26,10 @@ public class XdrDataInputStream
     public XdrDataInputStream(byte[] bytes)
     {
         _bytes = bytes;
+        if (bytes != null)
+        {
+            _stream = new MemoryStream(bytes, false);
+        }
     }
 
     /// <summary>
@@ -33,10 +38,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public byte Read()
     {
-        var res = _bytes[_pos];
-        _pos++;
-
-        return res;
+        Span<byte> buffer = stackalloc byte[1];
+        _stream.ReadExactly(buffer);
+        return buffer[0];
     }
 
     /// <summary>
@@ -82,28 +86,16 @@ public class XdrDataInputStream
 
     internal long ReadLong()
     {
-        return
-            ((long)_bytes[_pos++] << 56) |
-            ((long)_bytes[_pos++] << 48) |
-            ((long)_bytes[_pos++] << 40) |
-            ((long)_bytes[_pos++] << 32) |
-            ((long)_bytes[_pos++] << 24) |
-            ((long)_bytes[_pos++] << 16) |
-            ((long)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
-        return
-            ((ulong)_bytes[_pos++] << 56) |
-            ((ulong)_bytes[_pos++] << 48) |
-            ((ulong)_bytes[_pos++] << 40) |
-            ((ulong)_bytes[_pos++] << 32) |
-            ((ulong)_bytes[_pos++] << 24) |
-            ((ulong)_bytes[_pos++] << 16) |
-            ((ulong)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
     /// <summary>
@@ -112,11 +104,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public int ReadInt()
     {
-        return
-            (_bytes[_pos++] << 0x18) |
-            (_bytes[_pos++] << 0x10) |
-            (_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
     /// <summary>
@@ -125,17 +115,14 @@ public class XdrDataInputStream
     /// <returns></returns>
     public uint ReadUInt()
     {
-        return
-            ((uint)_bytes[_pos++] << 0x18) |
-            ((uint)_bytes[_pos++] << 0x10) |
-            ((uint)_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
-    public unsafe float ReadSingle()
+    public float ReadSingle()
     {
-        var num = ReadInt();
-        return *(float*)&num;
+        return BitConverter.Int32BitsToSingle(ReadInt());
     }
 
     /// <summary>
@@ -159,10 +146,9 @@ public class XdrDataInputStream
         return arr;
     }
 
-    public unsafe double ReadDouble()
+    public double ReadDouble()
     {
-        var num = ReadLong();
-        return *(double*)&num;
+        return BitConverter.Int64BitsToDouble(ReadLong());
     }
 
     /// <summary>
@@ -199,8 +185,8 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_bytes == null) return -1;
-        return _bytes.Length - _pos;
+        if (_stream == null) return -1;
+        return (int)(_stream.Length - _stream.Position);
     }
 
     /// <summary>
@@ -238,24 +224,20 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        Array.Copy(_bytes, _pos, result, 0, (int)len);
+        _stream.ReadExactly(result);
 
         if (tail == 0)
         {
-            _pos += (int)len;
             return result;
         }
 
         var tailBytes = new byte[tailLength];
-
-        Array.Copy(_bytes, _pos + len, tailBytes, 0, tailLength);
+        _stream.ReadExactly(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {
             throw new IOException("non-zero padding");
         }
-
-        _pos += (int)len + tailLength;
 
         return result;
     }

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/struct/XdrDataOutputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/struct/XdrDataOutputStream.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
 
@@ -66,47 +67,35 @@ public class XdrDataOutputStream
 
     public void WriteLong(long v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        BinaryPrimitives.WriteInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteULong(ulong v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteInt(int i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteUInt(uint i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
-    public unsafe void WriteSingle(float v)
+    public void WriteSingle(float v)
     {
-        WriteInt(*(int*)&v);
+        WriteInt(BitConverter.SingleToInt32Bits(v));
     }
 
     public void WriteSingleArray(float[] a)
@@ -123,9 +112,9 @@ public class XdrDataOutputStream
         }
     }
 
-    public unsafe void WriteDouble(double v)
+    public void WriteDouble(double v)
     {
-        WriteLong(*(long*)&v);
+        WriteLong(BitConverter.DoubleToInt64Bits(v));
     }
 
     public void WriteDoubleArray(double[] a)

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/test/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/test/XdrDataInputStream.cs
@@ -25,11 +25,9 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
+        ArgumentNullException.ThrowIfNull(bytes);
         _bytes = bytes;
-        if (bytes != null)
-        {
-            _stream = new MemoryStream(bytes, false);
-        }
+        _stream = new MemoryStream(bytes, false);
     }
 
     /// <summary>
@@ -185,7 +183,6 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_stream == null) return -1;
         return (int)(_stream.Length - _stream.Position);
     }
 

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/test/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/test/XdrDataInputStream.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -16,7 +17,7 @@ public class XdrDataInputStream
     public const int DefaultMaxDepth = 200;
 
     private readonly byte[] _bytes;
-    private int _pos;
+    private readonly MemoryStream _stream;
 
     /// <summary>
     ///     Create the stream from a byte array.
@@ -25,6 +26,10 @@ public class XdrDataInputStream
     public XdrDataInputStream(byte[] bytes)
     {
         _bytes = bytes;
+        if (bytes != null)
+        {
+            _stream = new MemoryStream(bytes, false);
+        }
     }
 
     /// <summary>
@@ -33,10 +38,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public byte Read()
     {
-        var res = _bytes[_pos];
-        _pos++;
-
-        return res;
+        Span<byte> buffer = stackalloc byte[1];
+        _stream.ReadExactly(buffer);
+        return buffer[0];
     }
 
     /// <summary>
@@ -82,28 +86,16 @@ public class XdrDataInputStream
 
     internal long ReadLong()
     {
-        return
-            ((long)_bytes[_pos++] << 56) |
-            ((long)_bytes[_pos++] << 48) |
-            ((long)_bytes[_pos++] << 40) |
-            ((long)_bytes[_pos++] << 32) |
-            ((long)_bytes[_pos++] << 24) |
-            ((long)_bytes[_pos++] << 16) |
-            ((long)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
-        return
-            ((ulong)_bytes[_pos++] << 56) |
-            ((ulong)_bytes[_pos++] << 48) |
-            ((ulong)_bytes[_pos++] << 40) |
-            ((ulong)_bytes[_pos++] << 32) |
-            ((ulong)_bytes[_pos++] << 24) |
-            ((ulong)_bytes[_pos++] << 16) |
-            ((ulong)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
     /// <summary>
@@ -112,11 +104,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public int ReadInt()
     {
-        return
-            (_bytes[_pos++] << 0x18) |
-            (_bytes[_pos++] << 0x10) |
-            (_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
     /// <summary>
@@ -125,17 +115,14 @@ public class XdrDataInputStream
     /// <returns></returns>
     public uint ReadUInt()
     {
-        return
-            ((uint)_bytes[_pos++] << 0x18) |
-            ((uint)_bytes[_pos++] << 0x10) |
-            ((uint)_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
-    public unsafe float ReadSingle()
+    public float ReadSingle()
     {
-        var num = ReadInt();
-        return *(float*)&num;
+        return BitConverter.Int32BitsToSingle(ReadInt());
     }
 
     /// <summary>
@@ -159,10 +146,9 @@ public class XdrDataInputStream
         return arr;
     }
 
-    public unsafe double ReadDouble()
+    public double ReadDouble()
     {
-        var num = ReadLong();
-        return *(double*)&num;
+        return BitConverter.Int64BitsToDouble(ReadLong());
     }
 
     /// <summary>
@@ -199,8 +185,8 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_bytes == null) return -1;
-        return _bytes.Length - _pos;
+        if (_stream == null) return -1;
+        return (int)(_stream.Length - _stream.Position);
     }
 
     /// <summary>
@@ -238,24 +224,20 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        Array.Copy(_bytes, _pos, result, 0, (int)len);
+        _stream.ReadExactly(result);
 
         if (tail == 0)
         {
-            _pos += (int)len;
             return result;
         }
 
         var tailBytes = new byte[tailLength];
-
-        Array.Copy(_bytes, _pos + len, tailBytes, 0, tailLength);
+        _stream.ReadExactly(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {
             throw new IOException("non-zero padding");
         }
-
-        _pos += (int)len + tailLength;
 
         return result;
     }

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/test/XdrDataOutputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/test/XdrDataOutputStream.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
 
@@ -66,47 +67,35 @@ public class XdrDataOutputStream
 
     public void WriteLong(long v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        BinaryPrimitives.WriteInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteULong(ulong v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteInt(int i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteUInt(uint i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
-    public unsafe void WriteSingle(float v)
+    public void WriteSingle(float v)
     {
-        WriteInt(*(int*)&v);
+        WriteInt(BitConverter.SingleToInt32Bits(v));
     }
 
     public void WriteSingleArray(float[] a)
@@ -123,9 +112,9 @@ public class XdrDataOutputStream
         }
     }
 
-    public unsafe void WriteDouble(double v)
+    public void WriteDouble(double v)
     {
-        WriteLong(*(long*)&v);
+        WriteLong(BitConverter.DoubleToInt64Bits(v));
     }
 
     public void WriteDoubleArray(double[] a)

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/union/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/union/XdrDataInputStream.cs
@@ -25,11 +25,9 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
+        ArgumentNullException.ThrowIfNull(bytes);
         _bytes = bytes;
-        if (bytes != null)
-        {
-            _stream = new MemoryStream(bytes, false);
-        }
+        _stream = new MemoryStream(bytes, false);
     }
 
     /// <summary>
@@ -185,7 +183,6 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_stream == null) return -1;
         return (int)(_stream.Length - _stream.Position);
     }
 

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/union/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/union/XdrDataInputStream.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -16,7 +17,7 @@ public class XdrDataInputStream
     public const int DefaultMaxDepth = 200;
 
     private readonly byte[] _bytes;
-    private int _pos;
+    private readonly MemoryStream _stream;
 
     /// <summary>
     ///     Create the stream from a byte array.
@@ -25,6 +26,10 @@ public class XdrDataInputStream
     public XdrDataInputStream(byte[] bytes)
     {
         _bytes = bytes;
+        if (bytes != null)
+        {
+            _stream = new MemoryStream(bytes, false);
+        }
     }
 
     /// <summary>
@@ -33,10 +38,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public byte Read()
     {
-        var res = _bytes[_pos];
-        _pos++;
-
-        return res;
+        Span<byte> buffer = stackalloc byte[1];
+        _stream.ReadExactly(buffer);
+        return buffer[0];
     }
 
     /// <summary>
@@ -82,28 +86,16 @@ public class XdrDataInputStream
 
     internal long ReadLong()
     {
-        return
-            ((long)_bytes[_pos++] << 56) |
-            ((long)_bytes[_pos++] << 48) |
-            ((long)_bytes[_pos++] << 40) |
-            ((long)_bytes[_pos++] << 32) |
-            ((long)_bytes[_pos++] << 24) |
-            ((long)_bytes[_pos++] << 16) |
-            ((long)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
-        return
-            ((ulong)_bytes[_pos++] << 56) |
-            ((ulong)_bytes[_pos++] << 48) |
-            ((ulong)_bytes[_pos++] << 40) |
-            ((ulong)_bytes[_pos++] << 32) |
-            ((ulong)_bytes[_pos++] << 24) |
-            ((ulong)_bytes[_pos++] << 16) |
-            ((ulong)_bytes[_pos++] << 8) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
     /// <summary>
@@ -112,11 +104,9 @@ public class XdrDataInputStream
     /// <returns></returns>
     public int ReadInt()
     {
-        return
-            (_bytes[_pos++] << 0x18) |
-            (_bytes[_pos++] << 0x10) |
-            (_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
     /// <summary>
@@ -125,17 +115,14 @@ public class XdrDataInputStream
     /// <returns></returns>
     public uint ReadUInt()
     {
-        return
-            ((uint)_bytes[_pos++] << 0x18) |
-            ((uint)_bytes[_pos++] << 0x10) |
-            ((uint)_bytes[_pos++] << 0x08) |
-            _bytes[_pos++];
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        _stream.ReadExactly(buffer);
+        return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
-    public unsafe float ReadSingle()
+    public float ReadSingle()
     {
-        var num = ReadInt();
-        return *(float*)&num;
+        return BitConverter.Int32BitsToSingle(ReadInt());
     }
 
     /// <summary>
@@ -159,10 +146,9 @@ public class XdrDataInputStream
         return arr;
     }
 
-    public unsafe double ReadDouble()
+    public double ReadDouble()
     {
-        var num = ReadLong();
-        return *(double*)&num;
+        return BitConverter.Int64BitsToDouble(ReadLong());
     }
 
     /// <summary>
@@ -199,8 +185,8 @@ public class XdrDataInputStream
     /// </summary>
     public int GetRemainingInputLen()
     {
-        if (_bytes == null) return -1;
-        return _bytes.Length - _pos;
+        if (_stream == null) return -1;
+        return (int)(_stream.Length - _stream.Position);
     }
 
     /// <summary>
@@ -238,24 +224,20 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        Array.Copy(_bytes, _pos, result, 0, (int)len);
+        _stream.ReadExactly(result);
 
         if (tail == 0)
         {
-            _pos += (int)len;
             return result;
         }
 
         var tailBytes = new byte[tailLength];
-
-        Array.Copy(_bytes, _pos + len, tailBytes, 0, tailLength);
+        _stream.ReadExactly(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {
             throw new IOException("non-zero padding");
         }
-
-        _pos += (int)len + tailLength;
 
         return result;
     }

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/union/XdrDataOutputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/union/XdrDataOutputStream.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT or your changes may be overwritten
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
 
@@ -66,47 +67,35 @@ public class XdrDataOutputStream
 
     public void WriteLong(long v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(long)];
+        BinaryPrimitives.WriteInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteULong(ulong v)
     {
-        Write((byte)((v >> 56) & 0xff));
-        Write((byte)((v >> 48) & 0xff));
-        Write((byte)((v >> 40) & 0xff));
-        Write((byte)((v >> 32) & 0xff));
-        Write((byte)((v >> 24) & 0xff));
-        Write((byte)((v >> 16) & 0xff));
-        Write((byte)((v >> 8) & 0xff));
-        Write((byte)(v & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteInt(int i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
     public void WriteUInt(uint i)
     {
-        Write((byte)((i >> 0x18) & 0xff));
-        Write((byte)((i >> 0x10) & 0xff));
-        Write((byte)((i >> 8) & 0xff));
-        Write((byte)(i & 0xff));
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
+        _bytes.AddRange(buffer);
     }
 
-    public unsafe void WriteSingle(float v)
+    public void WriteSingle(float v)
     {
-        WriteInt(*(int*)&v);
+        WriteInt(BitConverter.SingleToInt32Bits(v));
     }
 
     public void WriteSingleArray(float[] a)
@@ -123,9 +112,9 @@ public class XdrDataOutputStream
         }
     }
 
-    public unsafe void WriteDouble(double v)
+    public void WriteDouble(double v)
     {
-        WriteLong(*(long*)&v);
+        WriteLong(BitConverter.DoubleToInt64Bits(v));
     }
 
     public void WriteDoubleArray(double[] a)


### PR DESCRIPTION
## Auto-generated Summary 🤖
This PR addresses #165.

### Breaking changes
(Minor): `XdrDataInputStream` scalar reads now throw `EndOfStreamException` (was `IndexOutOfRangeException`) on truncated input.
<!-- Copilot: generate the summary here -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
