### PR TITLE
Multi-Target NuGet package: net10.0 + net8.0 + netstandard2.1

### DIFF
--- a/.github/workflows/pack_and_test.yml
+++ b/.github/workflows/pack_and_test.yml
@@ -30,7 +30,17 @@ jobs:
           ref: ${{github.head_ref}}
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: Restore
+        run: dotnet restore stellar-dotnet-sdk.sln
+      - name: Build all target frameworks
+        run: dotnet build stellar-dotnet-sdk.sln --configuration Release --no-restore
       - name: Pack
-        run: dotnet pack --configuration Release --output ${{env.NuGetDirectory}}
-      - name: Run unit tests
-        run: dotnet test StellarDotnetSdk.Tests/StellarDotnetSdk.Tests.csproj --configuration Release
+        run: dotnet pack stellar-dotnet-sdk.sln --configuration Release --no-build --output ${{env.NuGetDirectory}}
+      - name: Run unit tests (net10.0)
+        run: dotnet test StellarDotnetSdk.Tests/StellarDotnetSdk.Tests.csproj --configuration Release --no-build --framework net10.0
+      - name: Run unit tests (net8.0)
+        run: dotnet test StellarDotnetSdk.Tests/StellarDotnetSdk.Tests.csproj --configuration Release --no-build --framework net8.0
+      - name: Run unit tests (netstandard2.1 via net8.0 host)
+        run: dotnet test StellarDotnetSdk.NetStandard21.Tests/StellarDotnetSdk.NetStandard21.Tests.csproj --configuration Release --no-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,24 @@ All notable changes to this project are documented here. The format is based on
     existing credential variant (matching the JS reference SDK).
   - Signing output is verified byte-for-byte against `@stellar/stellar-sdk@16.0.0-rc.1` for the V2 and
     delegated paths via the known-answer vectors in `StellarDotnetSdk.Tests/TestData/generate-p27-auth-kat.mjs`.
+- **Multi-target NuGet packages: `net10.0`, `net8.0`, and `netstandard2.1`**
+  ([#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195), implements
+  [#162](https://github.com/Beans-BV/dotnet-stellar-sdk/issues/162)):
+  - `stellar-dotnet-sdk` and `stellar-dotnet-sdk-xdr` now ship all three target frameworks; NuGet picks
+    the best match automatically. `netstandard2.1` covers Unity 2022.3+/Unity 6, Tizen 5.5+, and other
+    portable-library hosts (see the new "Platform support" section in the README).
+  - Ed25519 backend per TFM: NSec.Cryptography 26.4.0 on `net10.0`, 25.4.0 on `net8.0`, and
+    Sodium.Core 1.4.1 on `netstandard2.1`. Backend equivalence is enforced by the new cross-provider
+    known-answer tests (`Ed25519CrossProviderTest`), and the full unit suite additionally runs against
+    the `netstandard2.1` build via the new `StellarDotnetSdk.NetStandard21.Tests` project.
+  - New `KycJsonOptions` (frozen `JsonSerializerOptions` singleton for SEP-0009 KYC types) and strict
+    `DateOnlyJsonConverter` / `NullableDateOnlyJsonConverter` (ISO `yyyy-MM-dd` only; malformed values
+    throw `JsonException` on deserialization).
+  - On `netstandard2.1`, the SEP-0009 date properties (`BirthDate`, `IdIssueDate`, `IdExpirationDate`,
+    `RegistrationDate`) are `string?` instead of `DateOnly?`; values are validated as ISO `yyyy-MM-dd`
+    when the fields are submitted (throwing `ArgumentException` otherwise, including from
+    `InteractiveService.DepositAsync`/`WithdrawAsync`), so the SEP-9 wire format is identical on every
+    TFM.
 
 ### Changed
 
@@ -33,9 +51,29 @@ All notable changes to this project are documented here. The format is based on
 - The `SorobanCredentials`, `SorobanSourceAccountCredentials`, and `SorobanAddressCredentials` classes
   moved from `InvokeHostFunctionOperation.cs` to a new `SorobanCredentials.cs` file. They remain in the
   `StellarDotnetSdk.Operations` namespace, so `using`/fully-qualified references are unaffected.
+- **Breaking (behavioral, `net8.0`):** the SDK no longer references the standalone `System.Text.Json`
+  10.0.6 package and uses each target framework's built-in System.Text.Json instead. As a result,
+  `AllowDuplicateProperties = false` and `RespectNullableAnnotations = true` on
+  `JsonOptions.DefaultOptions` now apply on `net10.0` only; on `net8.0` and `netstandard2.1`,
+  deserialization follows the STJ 8 defaults — the last duplicate JSON property wins and nullability
+  annotations are not enforced ([#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195)).
+- `KeyPair.Verify` no longer swallows every exception. Malformed or attacker-supplied signatures still
+  return `false` (`ArgumentException`, `FormatException`, and `CryptographicException` are caught), but
+  environmental failures — e.g. a missing native libsodium — now propagate instead of being misreported
+  as an invalid signature ([#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195)).
+- On `netstandard2.1`, the default HTTP handler is `HttpClientHandler` (`SocketsHttpHandler` on
+  `net8.0`/`net10.0`), and `RetryingHttpMessageHandler` overrides the synchronous `HttpClient.Send`
+  path only on `net8.0`/`net10.0` — use `SendAsync` on `netstandard2.1`
+  ([#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195)).
 
 ### Removed
 
 - **Breaking:** `SorobanSourceAccountCredentials.ToSorobanCredentialsXdr()` and
   `SorobanAddressCredentials.ToSorobanCredentialsXdr()`. Use `ToXdr()` instead (it now produces the same
   XDR via the `abstract`/`override` pair).
+
+### Fixed
+
+- `Util.Hash` no longer leaks a `SHA256` instance on every call: it uses the static
+  `SHA256.HashData` on `net8.0`/`net10.0` and a properly disposed instance on `netstandard2.1`
+  ([#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195)).

--- a/README.md
+++ b/README.md
@@ -62,6 +62,23 @@ The `stellar-dotnet-sdk` library is bundled in a NuGet package.
 
 - [Ways to install a NuGet package](https://docs.microsoft.com/en-us/nuget/consume-packages/overview-and-workflow#ways-to-install-a-nuget-package)
 
+## Platform support
+
+The `stellar-dotnet-sdk` and `stellar-dotnet-sdk-xdr` packages multi-target the following frameworks:
+
+| Target framework | Typical platforms | Crypto backend |
+|------------------|-------------------|----------------|
+| `net10.0` | .NET 10 apps | NSec |
+| `net8.0` | .NET 8 apps | NSec |
+| `netstandard2.1` | Unity 2022.3+, Unity 6, Tizen 5.5+, portable libraries | Sodium.Core |
+
+NuGet resolves the best matching assembly for your project automatically.
+
+### TFM-specific API notes
+
+- **SEP-0009 date fields** (`BirthDate`, `IdIssueDate`, `IdExpirationDate`, `RegistrationDate`): `DateOnly?` on `net8.0` / `net10.0`; `string?` (ISO `yyyy-MM-dd`) on `netstandard2.1`. JSON wire format is identical across TFMs.
+- **Synchronous `HttpClient.Send` resilience**: `RetryingHttpMessageHandler` overrides sync `Send` only on `net8.0` / `net10.0`. Use `SendAsync` on `netstandard2.1`.
+
 ### Examples
 
 The SDK includes numerous example applications showcasing its features. Explore these standalone projects:

--- a/StellarDotnetSdk.NetStandard21.Tests/StellarDotnetSdk.NetStandard21.Tests.csproj
+++ b/StellarDotnetSdk.NetStandard21.Tests/StellarDotnetSdk.NetStandard21.Tests.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <Nullable>enable</Nullable>
+        <LangVersion>12</LangVersion>
+        <RootNamespace>StellarDotnetSdk.Tests</RootNamespace>
+        <DefineConstants>$(DefineConstants);TEST_SDK_NETSTANDARD21</DefineConstants>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Appveyor.TestLogger" Version="2.0.0"/>
+        <PackageReference Include="FakeItEasy" Version="7.3.1"/>
+        <PackageReference Include="Fare" Version="2.2.1"/>
+        <PackageReference Include="FluentAssertions" Version="6.7.0"/>
+        <PackageReference Include="FsCheck.NUnit" Version="2.16.5"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="Moq" Version="4.18.2"/>
+        <PackageReference Include="MSTest.TestAdapter" Version="2.2.10"/>
+        <PackageReference Include="MSTest.TestFramework" Version="2.2.10"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0"/>
+        <PackageReference Include="Sodium.Core" Version="1.4.1"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\StellarDotnetSdk\StellarDotnetSdk.csproj"
+                          AdditionalProperties="TargetFramework=netstandard2.1"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Compile Include="..\StellarDotnetSdk.Tests\**\*.cs"
+                 Exclude="..\StellarDotnetSdk.Tests\obj\**\*;..\StellarDotnetSdk.Tests\bin\**\*"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="..\StellarDotnetSdk.Tests\TestData\**\*"
+              Link="TestData\%(RecursiveDir)%(Filename)%(Extension)"
+              CopyToOutputDirectory="PreserveNewest"/>
+        <None Include="..\StellarDotnetSdk.Tests\wasm\**\*"
+              Link="wasm\%(RecursiveDir)%(Filename)%(Extension)"
+              CopyToOutputDirectory="PreserveNewest"/>
+    </ItemGroup>
+</Project>

--- a/StellarDotnetSdk.Tests/Accounts/KeyPairBIP39Tests.cs
+++ b/StellarDotnetSdk.Tests/Accounts/KeyPairBIP39Tests.cs
@@ -283,7 +283,7 @@ public class KeyPairBip39Tests
             Assert.AreEqual(expectedSecret, pair1.SecretSeed);
 
             // Act - Test with byte array seed
-            var pair2 = KeyPair.FromBIP39Seed(bip39Seed.HexToByteArray(), accountIndex);
+            var pair2 = KeyPair.FromBIP39Seed(Util.HexToBytes(bip39Seed), accountIndex);
 
             // Assert - Verify byte array seed derivation
             Assert.AreEqual(expectedAccountId, pair2.AccountId);

--- a/StellarDotnetSdk.Tests/Accounts/KeyPairTest.cs
+++ b/StellarDotnetSdk.Tests/Accounts/KeyPairTest.cs
@@ -227,10 +227,7 @@ public class KeyPairTest
         var sig = keypair.SignPayloadDecorated(payload);
 
         // Assert
-        for (var i = 0; i < sig.Hint.InnerValue.Length; i++)
-        {
-            sig.Hint.InnerValue[i] = expectedBytes[i];
-        }
+        CollectionAssert.AreEqual(expectedBytes, sig.Hint.InnerValue);
     }
 
 
@@ -250,9 +247,6 @@ public class KeyPairTest
         var sig = keypair.SignPayloadDecorated(payload);
 
         // Assert
-        for (var i = 0; i < sig.Hint.InnerValue.Length; i++)
-        {
-            sig.Hint.InnerValue[i] = expectedBytes[i];
-        }
+        CollectionAssert.AreEqual(expectedBytes, sig.Hint.InnerValue);
     }
 }

--- a/StellarDotnetSdk.Tests/Converters/JsonOptionsTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/JsonOptionsTest.cs
@@ -12,6 +12,8 @@ namespace StellarDotnetSdk.Tests.Converters;
 [TestClass]
 public class JsonOptionsTest
 {
+    // AllowDuplicateProperties is only available (and enabled by JsonOptions) on net10.0+.
+#if NET10_0_OR_GREATER
     /// <summary>
     ///     The shared options must disable <c>AllowDuplicateProperties</c> so malformed JSON
     ///     cannot silently overwrite financial fields.
@@ -47,6 +49,7 @@ public class JsonOptionsTest
         Assert.ThrowsException<JsonException>(() =>
             JsonSerializer.Deserialize<Payment>(json, JsonOptions.DefaultOptions));
     }
+#endif
 
     /// <summary>
     ///     Well-formed JSON without duplicates must still deserialize successfully so that
@@ -72,6 +75,8 @@ public class JsonOptionsTest
         Assert.AreEqual("100.00", payment.Amount);
     }
 
+    // AllowDuplicateProperties is only available (and enabled by JsonOptions) on net10.0+.
+#if NET10_0_OR_GREATER
     /// <summary>
     ///     Case-insensitive matching is also in effect, so two properties that differ only in
     ///     casing must still be rejected as duplicates.
@@ -92,7 +97,10 @@ public class JsonOptionsTest
         Assert.ThrowsException<JsonException>(() =>
             JsonSerializer.Deserialize<Payment>(json, JsonOptions.DefaultOptions));
     }
+#endif
 
+    // RespectNullableAnnotations is only available (and enabled by JsonOptions) on net10.0+.
+#if NET10_0_OR_GREATER
     /// <summary>
     ///     Verifies that <see cref="JsonOptions.DefaultOptions" /> has
     ///     <see cref="JsonSerializerOptions.RespectNullableAnnotations" /> enabled.
@@ -118,6 +126,7 @@ public class JsonOptionsTest
         Assert.ThrowsException<JsonException>(() =>
             JsonSerializer.Deserialize<SampleDto>(json, JsonOptions.DefaultOptions));
     }
+#endif
 
     /// <summary>
     ///     Tests deserialization of JSON where a nullable reference property is null.

--- a/StellarDotnetSdk.Tests/Crypto/Ed25519CrossProviderTest.cs
+++ b/StellarDotnetSdk.Tests/Crypto/Ed25519CrossProviderTest.cs
@@ -1,0 +1,314 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#if NET10_0_OR_GREATER && !TEST_SDK_NETSTANDARD21
+using NSec.Cryptography;
+using Sodium;
+#endif
+
+namespace StellarDotnetSdk.Tests.Crypto;
+
+#if NET10_0_OR_GREATER && !TEST_SDK_NETSTANDARD21
+
+/// <summary>
+///     Cross-provider Ed25519 compatibility tests between NSec and Sodium.Core (net10.0 only).
+///     net8.0 cannot load both native libsodium versions; netstandard2.1 uses Sodium via the SDK.
+/// </summary>
+[TestClass]
+public class Ed25519CrossProviderTest
+{
+    private const string KeyPairTestSeedHex =
+        "1123740522f11bfef6b3671f51e159ccf589ccf8965262dd5f97d1721d383dd4";
+
+    private const string KeyPairTestSignatureHex =
+        "587d4b472eeef7d07aafcd0b049640b0bb3f39784118c2e2b73a04fa2f64c9c538b4b2d0f5335e968a480021fdc23e98c0ddf424cb15d8131df8cb6c4bb58309";
+
+    private static readonly byte[] Rfc8032Seed = Convert.FromHexString(
+        "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
+
+    private static readonly byte[] Rfc8032PublicKey = Convert.FromHexString(
+        "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a");
+
+    private static readonly byte[] Rfc8032Signature = Convert.FromHexString(
+        "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e06522490155" +
+        "5fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b");
+
+    [TestMethod]
+    public void Rfc8032_TestVector1_ProducesExpectedPublicKeyAndSignature()
+    {
+        var message = Array.Empty<byte>();
+
+        CollectionAssert.AreEqual(Rfc8032PublicKey, Ed25519Nsec.GetPublicKey(Rfc8032Seed));
+        CollectionAssert.AreEqual(Rfc8032PublicKey, Ed25519Sodium.GetPublicKey(Rfc8032Seed));
+
+        CollectionAssert.AreEqual(Rfc8032Signature, Ed25519Nsec.Sign(Rfc8032Seed, message));
+        CollectionAssert.AreEqual(Rfc8032Signature, Ed25519Sodium.Sign(Rfc8032Seed, message));
+    }
+
+    [TestMethod]
+    public void KeyPairTestVector_ProducesExpectedSignatureForHelloWorld()
+    {
+        var seed = StellarDotnetSdk.Util.HexToBytes(KeyPairTestSeedHex);
+        var message = Encoding.UTF8.GetBytes("hello world");
+        var expectedSignature = StellarDotnetSdk.Util.HexToBytes(KeyPairTestSignatureHex);
+
+        CollectionAssert.AreEqual(expectedSignature, Ed25519Nsec.Sign(seed, message));
+        CollectionAssert.AreEqual(expectedSignature, Ed25519Sodium.Sign(seed, message));
+    }
+
+    [TestMethod]
+    public void SameSeed_ProducesSamePublicKey()
+    {
+        var seed = RandomNumberGenerator.GetBytes(32);
+
+        var nsecPublicKey = Ed25519Nsec.GetPublicKey(seed);
+        var sodiumPublicKey = Ed25519Sodium.GetPublicKey(seed);
+
+        CollectionAssert.AreEqual(nsecPublicKey, sodiumPublicKey);
+        Assert.AreEqual(32, nsecPublicKey.Length);
+    }
+
+    [TestMethod]
+    public void SameSeedAndMessage_ProducesSameSignature()
+    {
+        var seed = RandomNumberGenerator.GetBytes(32);
+        var message = RandomNumberGenerator.GetBytes(128);
+
+        var nsecSignature = Ed25519Nsec.Sign(seed, message);
+        var sodiumSignature = Ed25519Sodium.Sign(seed, message);
+
+        CollectionAssert.AreEqual(nsecSignature, sodiumSignature);
+        Assert.AreEqual(64, nsecSignature.Length);
+    }
+
+    [TestMethod]
+    public void NSecSignature_VerifiesWithSodium()
+    {
+        var seed = RandomNumberGenerator.GetBytes(32);
+        var message = RandomNumberGenerator.GetBytes(256);
+
+        var publicKey = Ed25519Sodium.GetPublicKey(seed);
+        var signature = Ed25519Nsec.Sign(seed, message);
+
+        Assert.IsTrue(Ed25519Sodium.Verify(publicKey, message, signature));
+    }
+
+    [TestMethod]
+    public void SodiumSignature_VerifiesWithNSec()
+    {
+        var seed = RandomNumberGenerator.GetBytes(32);
+        var message = RandomNumberGenerator.GetBytes(256);
+
+        var publicKey = Ed25519Nsec.GetPublicKey(seed);
+        var signature = Ed25519Sodium.Sign(seed, message);
+
+        Assert.IsTrue(Ed25519Nsec.Verify(publicKey, message, signature));
+    }
+
+    [TestMethod]
+    public void MutatedMessage_FailsVerificationOnBothProviders()
+    {
+        var seed = RandomNumberGenerator.GetBytes(32);
+        var message = RandomNumberGenerator.GetBytes(64);
+
+        var publicKey = Ed25519Nsec.GetPublicKey(seed);
+        var signature = Ed25519Sodium.Sign(seed, message);
+
+        message[0] ^= 0x01;
+
+        Assert.IsFalse(Ed25519Nsec.Verify(publicKey, message, signature));
+        Assert.IsFalse(Ed25519Sodium.Verify(publicKey, message, signature));
+    }
+
+    [TestMethod]
+    public void MutatedSignature_FailsVerificationOnBothProviders()
+    {
+        var seed = RandomNumberGenerator.GetBytes(32);
+        var message = RandomNumberGenerator.GetBytes(64);
+
+        var publicKey = Ed25519Nsec.GetPublicKey(seed);
+        var signature = Ed25519Nsec.Sign(seed, message);
+        signature[0] ^= 0x01;
+
+        Assert.IsFalse(Ed25519Nsec.Verify(publicKey, message, signature));
+        Assert.IsFalse(Ed25519Sodium.Verify(publicKey, message, signature));
+    }
+
+    [TestMethod]
+    public void InvalidSeedLength_ThrowsOnBothProviders()
+    {
+        var invalidSeed = RandomNumberGenerator.GetBytes(31);
+
+        Assert.ThrowsException<ArgumentException>(() => Ed25519Nsec.GetPublicKey(invalidSeed));
+        Assert.ThrowsException<ArgumentException>(() => Ed25519Sodium.GetPublicKey(invalidSeed));
+        Assert.ThrowsException<ArgumentException>(() => Ed25519Nsec.Sign(invalidSeed, [1]));
+        Assert.ThrowsException<ArgumentException>(() => Ed25519Sodium.Sign(invalidSeed, [1]));
+    }
+
+    [TestMethod]
+    public void Randomized_ProvidersAreEquivalent_For1000Iterations()
+    {
+        for (var i = 0; i < 1000; i++)
+        {
+            var seed = RandomNumberGenerator.GetBytes(32);
+            var message = RandomNumberGenerator.GetBytes(RandomNumberGenerator.GetInt32(0, 4096));
+
+            var nsecPublicKey = Ed25519Nsec.GetPublicKey(seed);
+            var sodiumPublicKey = Ed25519Sodium.GetPublicKey(seed);
+            CollectionAssert.AreEqual(nsecPublicKey, sodiumPublicKey);
+
+            var nsecSignature = Ed25519Nsec.Sign(seed, message);
+            var sodiumSignature = Ed25519Sodium.Sign(seed, message);
+            CollectionAssert.AreEqual(nsecSignature, sodiumSignature);
+
+            Assert.IsTrue(Ed25519Sodium.Verify(nsecPublicKey, message, nsecSignature));
+            Assert.IsTrue(Ed25519Nsec.Verify(sodiumPublicKey, message, sodiumSignature));
+
+            var mutatedSignature = (byte[])nsecSignature.Clone();
+            mutatedSignature[0] ^= 0x01;
+            Assert.IsFalse(Ed25519Nsec.Verify(nsecPublicKey, message, mutatedSignature));
+            Assert.IsFalse(Ed25519Sodium.Verify(sodiumPublicKey, message, mutatedSignature));
+        }
+    }
+
+    private static class Ed25519Nsec
+    {
+        public const int SeedLength = 32;
+        public const int PublicKeyLength = 32;
+
+        public static byte[] GetPublicKey(byte[] seed)
+        {
+            ValidateSeed(seed);
+
+            using var key = Key.Import(
+                SignatureAlgorithm.Ed25519,
+                seed,
+                KeyBlobFormat.RawPrivateKey,
+                new KeyCreationParameters
+                {
+                    ExportPolicy = KeyExportPolicies.AllowPlaintextExport,
+                });
+
+            return key.PublicKey.Export(KeyBlobFormat.RawPublicKey);
+        }
+
+        public static byte[] Sign(byte[] seed, byte[] message)
+        {
+            ValidateSeed(seed);
+
+            using var key = Key.Import(
+                SignatureAlgorithm.Ed25519,
+                seed,
+                KeyBlobFormat.RawPrivateKey,
+                new KeyCreationParameters
+                {
+                    ExportPolicy = KeyExportPolicies.AllowPlaintextExport,
+                });
+
+            return SignatureAlgorithm.Ed25519.Sign(key, message);
+        }
+
+        public static bool Verify(byte[] publicKey, byte[] message, byte[] signature)
+        {
+            if (publicKey == null)
+            {
+                throw new ArgumentNullException(nameof(publicKey));
+            }
+
+            if (publicKey.Length != PublicKeyLength)
+            {
+                throw new ArgumentException($"PublicKey must be {PublicKeyLength} bytes.", nameof(publicKey));
+            }
+
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            if (signature == null)
+            {
+                throw new ArgumentNullException(nameof(signature));
+            }
+
+            var pk = PublicKey.Import(
+                SignatureAlgorithm.Ed25519,
+                publicKey,
+                KeyBlobFormat.RawPublicKey);
+
+            return SignatureAlgorithm.Ed25519.Verify(pk, message, signature);
+        }
+
+        private static void ValidateSeed(byte[] seed)
+        {
+            if (seed == null)
+            {
+                throw new ArgumentNullException(nameof(seed));
+            }
+
+            if (seed.Length != SeedLength)
+            {
+                throw new ArgumentException($"Seed must be {SeedLength} bytes.", nameof(seed));
+            }
+        }
+    }
+
+    private static class Ed25519Sodium
+    {
+        public const int SeedLength = 32;
+        public const int PublicKeyLength = 32;
+
+        public static byte[] GetPublicKey(byte[] seed)
+        {
+            ValidateSeed(seed);
+            var kp = PublicKeyAuth.GenerateKeyPair(seed);
+            return kp.PublicKey;
+        }
+
+        public static byte[] Sign(byte[] seed, byte[] message)
+        {
+            ValidateSeed(seed);
+            var kp = PublicKeyAuth.GenerateKeyPair(seed);
+            return PublicKeyAuth.SignDetached(message, kp.PrivateKey);
+        }
+
+        public static bool Verify(byte[] publicKey, byte[] message, byte[] signature)
+        {
+            if (publicKey == null)
+            {
+                throw new ArgumentNullException(nameof(publicKey));
+            }
+
+            if (publicKey.Length != PublicKeyLength)
+            {
+                throw new ArgumentException($"PublicKey must be {PublicKeyLength} bytes.", nameof(publicKey));
+            }
+
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            if (signature == null)
+            {
+                throw new ArgumentNullException(nameof(signature));
+            }
+
+            return PublicKeyAuth.VerifyDetached(signature, message, publicKey);
+        }
+
+        private static void ValidateSeed(byte[] seed)
+        {
+            if (seed == null)
+            {
+                throw new ArgumentNullException(nameof(seed));
+            }
+
+            if (seed.Length != SeedLength)
+            {
+                throw new ArgumentException($"Seed must be {SeedLength} bytes.", nameof(seed));
+            }
+        }
+    }
+}
+#endif

--- a/StellarDotnetSdk.Tests/Requests/RetryingHttpMessageHandlerTests.cs
+++ b/StellarDotnetSdk.Tests/Requests/RetryingHttpMessageHandlerTests.cs
@@ -948,7 +948,9 @@ public class RetryingHttpMessageHandlerTests
     /// <summary>
     ///     The synchronous HttpClient.Send path must run through the same resilience pipeline as SendAsync
     ///     instead of silently bypassing it via the inherited DelegatingHandler.Send.
+    ///     Skipped when testing the netstandard2.1 SDK build, which does not override synchronous Send.
     /// </summary>
+#if !TEST_SDK_NETSTANDARD21
     [TestMethod]
     public void Send_SynchronousPath_RetriesThroughPipeline()
     {
@@ -969,6 +971,7 @@ public class RetryingHttpMessageHandlerTests
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
         Assert.AreEqual(2, inner.CallCount); // first attempt threw, the synchronous retry succeeded
     }
+#endif
 
     /// <summary>
     ///     Circuit-breaker failure counting is not limited by the RetryHttpMethods whitelist: a sustained

--- a/StellarDotnetSdk.Tests/Sep/Sep0009/Fixtures/KycTestDates.cs
+++ b/StellarDotnetSdk.Tests/Sep/Sep0009/Fixtures/KycTestDates.cs
@@ -1,0 +1,29 @@
+#if TEST_SDK_NETSTANDARD21
+namespace StellarDotnetSdk.Tests.Sep.Sep0009.Fixtures;
+
+internal static class KycTestDates
+{
+    internal const string BirthDate = "1990-01-15";
+    internal const string IdIssueDate = "2020-05-10";
+    internal const string IdExpirationDate = "2030-05-10";
+    internal const string RegistrationDate = "2020-01-01";
+    internal const string RegistrationDateIso = "2020-01-15";
+    internal const string NestedBirthDate = "1985-12-25";
+    internal const string NestedRegistrationDate = "2010-06-01";
+}
+#else
+using System;
+
+namespace StellarDotnetSdk.Tests.Sep.Sep0009.Fixtures;
+
+internal static class KycTestDates
+{
+    internal static DateOnly BirthDate => new(1990, 1, 15);
+    internal static DateOnly IdIssueDate => new(2020, 5, 10);
+    internal static DateOnly IdExpirationDate => new(2030, 5, 10);
+    internal static DateOnly RegistrationDate => new(2020, 1, 1);
+    internal static DateOnly RegistrationDateIso => new(2020, 1, 15);
+    internal static DateOnly NestedBirthDate => new(1985, 12, 25);
+    internal static DateOnly NestedRegistrationDate => new(2010, 6, 1);
+}
+#endif

--- a/StellarDotnetSdk.Tests/Sep/Sep0009/KycJsonSerializationTest.cs
+++ b/StellarDotnetSdk.Tests/Sep/Sep0009/KycJsonSerializationTest.cs
@@ -105,7 +105,7 @@ public class KycJsonSerializationTest
 
         var act = () => JsonSerializer.Deserialize<NaturalPersonKycFields>(json, KycJsonOptions.Default);
 
-        act.Should().Throw<FormatException>();
+        act.Should().Throw<JsonException>();
     }
 #endif
 }

--- a/StellarDotnetSdk.Tests/Sep/Sep0009/KycJsonSerializationTest.cs
+++ b/StellarDotnetSdk.Tests/Sep/Sep0009/KycJsonSerializationTest.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StellarDotnetSdk.Converters;
+using StellarDotnetSdk.Sep.Sep0009;
+using StellarDotnetSdk.Tests.Sep.Sep0009.Fixtures;
+
+namespace StellarDotnetSdk.Tests.Sep.Sep0009;
+
+/// <summary>
+///     JSON serialization tests for SEP-0009 KYC field types.
+/// </summary>
+[TestClass]
+public class KycJsonSerializationTest
+{
+    [TestMethod]
+    public void NaturalPersonKycFields_JsonRoundTrip_PreservesDateFields()
+    {
+        var json = """
+            {
+              "firstName": "John",
+              "birthDate": "1990-01-15",
+              "idIssueDate": "2020-05-10",
+              "idExpirationDate": "2030-05-10"
+            }
+            """;
+
+        var fields = JsonSerializer.Deserialize<NaturalPersonKycFields>(json, KycJsonOptions.Default);
+
+        fields.Should().NotBeNull();
+        fields!.FirstName.Should().Be("John");
+        fields.BirthDate.Should().Be(KycTestDates.BirthDate);
+        fields.IdIssueDate.Should().Be(KycTestDates.IdIssueDate);
+        fields.IdExpirationDate.Should().Be(KycTestDates.IdExpirationDate);
+
+#if !TEST_SDK_NETSTANDARD21
+        var roundTrip = JsonSerializer.Serialize(fields, KycJsonOptions.Default);
+        roundTrip.Should().Contain("\"birthDate\":\"1990-01-15\"");
+        roundTrip.Should().Contain("\"idIssueDate\":\"2020-05-10\"");
+        roundTrip.Should().Contain("\"idExpirationDate\":\"2030-05-10\"");
+#endif
+    }
+
+    [TestMethod]
+    public void OrganizationKycFields_JsonRoundTrip_PreservesRegistrationDate()
+    {
+        var json = """
+            {
+              "name": "Acme Corp",
+              "registrationDate": "2020-01-15"
+            }
+            """;
+
+        var fields = JsonSerializer.Deserialize<OrganizationKycFields>(json, KycJsonOptions.Default);
+
+        fields.Should().NotBeNull();
+        fields!.Name.Should().Be("Acme Corp");
+        fields.RegistrationDate.Should().Be(KycTestDates.RegistrationDateIso);
+
+#if !TEST_SDK_NETSTANDARD21
+        var roundTrip = JsonSerializer.Serialize(fields, KycJsonOptions.Default);
+        roundTrip.Should().Contain("\"registrationDate\":\"2020-01-15\"");
+#endif
+    }
+
+    [TestMethod]
+    public void StandardKycFields_JsonRoundTrip_PreservesNestedDates()
+    {
+        var json = """
+            {
+              "naturalPerson": {
+                "birthDate": "1985-12-25"
+              },
+              "organization": {
+                "registrationDate": "2010-06-01"
+              }
+            }
+            """;
+
+        var fields = JsonSerializer.Deserialize<StandardKycFields>(json, KycJsonOptions.Default);
+
+        fields.Should().NotBeNull();
+        fields!.NaturalPerson!.BirthDate.Should().Be(KycTestDates.NestedBirthDate);
+        fields.Organization!.RegistrationDate.Should().Be(KycTestDates.NestedRegistrationDate);
+    }
+
+#if NET8_0_OR_GREATER && !TEST_SDK_NETSTANDARD21
+    [TestMethod]
+    public void JsonOptions_DefaultOptions_IsReadOnly()
+    {
+        JsonOptions.DefaultOptions.IsReadOnly.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void KycJsonOptions_Default_IsReadOnly()
+    {
+        KycJsonOptions.Default.IsReadOnly.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void NullableDateOnlyJsonConverter_RejectsInvalidDateFormat()
+    {
+        var json = """{"birthDate":"15-01-1990"}""";
+
+        var act = () => JsonSerializer.Deserialize<NaturalPersonKycFields>(json, KycJsonOptions.Default);
+
+        act.Should().Throw<FormatException>();
+    }
+#endif
+}

--- a/StellarDotnetSdk.Tests/Sep/Sep0009/NaturalPersonKycFieldsTest.cs
+++ b/StellarDotnetSdk.Tests/Sep/Sep0009/NaturalPersonKycFieldsTest.cs
@@ -2,6 +2,7 @@ using System;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using StellarDotnetSdk.Sep.Sep0009;
+using StellarDotnetSdk.Tests.Sep.Sep0009.Fixtures;
 
 namespace StellarDotnetSdk.Tests.Sep.Sep0009;
 
@@ -79,22 +80,17 @@ public class NaturalPersonKycFieldsTest
     [TestMethod]
     public void DateProperties_SetAndGet_WorkCorrectly()
     {
-        // Arrange
-        var birthDate = new DateOnly(1990, 1, 15);
-        var idIssueDate = new DateOnly(2020, 5, 10);
-        var idExpirationDate = new DateOnly(2030, 5, 10);
-
         var fields = new NaturalPersonKycFields
         {
-            BirthDate = birthDate,
-            IdIssueDate = idIssueDate,
-            IdExpirationDate = idExpirationDate,
+            BirthDate = KycTestDates.BirthDate,
+            IdIssueDate = KycTestDates.IdIssueDate,
+            IdExpirationDate = KycTestDates.IdExpirationDate,
         };
 
         // Assert
-        fields.BirthDate.Should().Be(birthDate);
-        fields.IdIssueDate.Should().Be(idIssueDate);
-        fields.IdExpirationDate.Should().Be(idExpirationDate);
+        fields.BirthDate.Should().Be(KycTestDates.BirthDate);
+        fields.IdIssueDate.Should().Be(KycTestDates.IdIssueDate);
+        fields.IdExpirationDate.Should().Be(KycTestDates.IdExpirationDate);
     }
 
     /// <summary>
@@ -239,9 +235,9 @@ public class NaturalPersonKycFieldsTest
         // Arrange
         var fields = new NaturalPersonKycFields
         {
-            BirthDate = new DateOnly(1990, 1, 15),
-            IdIssueDate = new DateOnly(2020, 5, 10),
-            IdExpirationDate = new DateOnly(2030, 5, 10),
+            BirthDate = KycTestDates.BirthDate,
+            IdIssueDate = KycTestDates.IdIssueDate,
+            IdExpirationDate = KycTestDates.IdExpirationDate,
         };
 
         // Act

--- a/StellarDotnetSdk.Tests/Sep/Sep0009/NaturalPersonKycFieldsTest.cs
+++ b/StellarDotnetSdk.Tests/Sep/Sep0009/NaturalPersonKycFieldsTest.cs
@@ -250,6 +250,22 @@ public class NaturalPersonKycFieldsTest
             .Be("2030-05-10");
     }
 
+#if TEST_SDK_NETSTANDARD21
+    /// <summary>
+    ///     Verifies that GetFields rejects non-canonical date strings on netstandard2.1 so SEP-9 wire format matches net8+.
+    /// </summary>
+    [TestMethod]
+    public void GetFields_WithNonCanonicalDateString_ThrowsArgumentException()
+    {
+        var fields = new NaturalPersonKycFields { BirthDate = "6/9/2026" };
+
+        var act = () => fields.GetFields();
+
+        act.Should().Throw<ArgumentException>()
+            .WithParameterName(NaturalPersonKycFields.BirthDateFieldKey);
+    }
+#endif
+
     /// <summary>
     ///     Verifies that GetFields formats int values as strings.
     /// </summary>

--- a/StellarDotnetSdk.Tests/Sep/Sep0009/OrganizationKycFieldsTest.cs
+++ b/StellarDotnetSdk.Tests/Sep/Sep0009/OrganizationKycFieldsTest.cs
@@ -2,6 +2,7 @@ using System;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using StellarDotnetSdk.Sep.Sep0009;
+using StellarDotnetSdk.Tests.Sep.Sep0009.Fixtures;
 
 namespace StellarDotnetSdk.Tests.Sep.Sep0009;
 
@@ -18,13 +19,12 @@ public class OrganizationKycFieldsTest
     public void TextProperties_SetAndGet_WorkCorrectly()
     {
         // Arrange
-        var registrationDate = new DateOnly(2020, 1, 1);
         var fields = new OrganizationKycFields
         {
             Name = "Acme Corp",
             VatNumber = "VAT123456",
             RegistrationNumber = "REG789012",
-            RegistrationDate = registrationDate,
+            RegistrationDate = KycTestDates.RegistrationDate,
             RegisteredAddress = "123 Business St",
             ShareholderName = "John Doe",
             AddressCountryCode = "USA",
@@ -41,7 +41,7 @@ public class OrganizationKycFieldsTest
         fields.Name.Should().Be("Acme Corp");
         fields.VatNumber.Should().Be("VAT123456");
         fields.RegistrationNumber.Should().Be("REG789012");
-        fields.RegistrationDate.Should().Be(registrationDate);
+        fields.RegistrationDate.Should().Be(KycTestDates.RegistrationDate);
         fields.RegisteredAddress.Should().Be("123 Business St");
         fields.ShareholderName.Should().Be("John Doe");
         fields.AddressCountryCode.Should().Be("USA");
@@ -115,13 +115,12 @@ public class OrganizationKycFieldsTest
     public void GetFields_WithAllTextFieldsSet_ReturnsAllFields()
     {
         // Arrange
-        var registrationDate = new DateOnly(2020, 1, 1);
         var fields = new OrganizationKycFields
         {
             Name = "Acme Corp",
             VatNumber = "VAT123456",
             RegistrationNumber = "REG789012",
-            RegistrationDate = registrationDate,
+            RegistrationDate = KycTestDates.RegistrationDate,
             RegisteredAddress = "123 Business St",
             ShareholderName = "John Doe",
             AddressCountryCode = "USA",
@@ -165,7 +164,7 @@ public class OrganizationKycFieldsTest
         // Arrange
         var fields = new OrganizationKycFields
         {
-            RegistrationDate = new DateOnly(2020, 1, 15),
+            RegistrationDate = KycTestDates.RegistrationDateIso,
         };
 
         // Act

--- a/StellarDotnetSdk.Tests/StellarDotnetSdk.Tests.csproj
+++ b/StellarDotnetSdk.Tests/StellarDotnetSdk.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>
         <LangVersion>12</LangVersion>
@@ -26,6 +26,10 @@
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.10"/>
         <PackageReference Include="MSTest.TestFramework" Version="2.2.10"/>
         <PackageReference Include="SpecFlow.MsTest" Version="3.9.74"/>
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="NSec.Cryptography" Version="26.4.0"/>
+        <PackageReference Include="Sodium.Core" Version="1.4.1"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\StellarDotnetSdk\StellarDotnetSdk.csproj"/>
@@ -469,13 +473,5 @@
         <None Update="TestData\Responses\Operations\invokeHostFunction.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Remove="KeyPairBIP39Tests.cs"/>
-        <Compile Remove="KeyPairTest.cs"/>
-        <Compile Remove="MuxedAccountTest.cs"/>
-        <Compile Remove="AssetAmountTest.cs"/>
-        <Compile Remove="AssetTest.cs"/>
-        <Compile Remove="TransactionPreconditionsTest.cs"/>
     </ItemGroup>
 </Project>

--- a/StellarDotnetSdk.Tests/Utils.cs
+++ b/StellarDotnetSdk.Tests/Utils.cs
@@ -36,14 +36,21 @@ namespace StellarDotnetSdk.Tests;
 
 public static class Utils
 {
+    private const string SourceTestProjectName = "StellarDotnetSdk.Tests";
+
     /// <summary>
     ///     Gets the root path of the test project (StellarDotnetSdk.Tests directory).
     ///     This is calculated by going up 4 levels from AppContext.BaseDirectory
     ///     (bin/Debug/net8.0 -> Debug -> bin -> StellarDotnetSdk.Tests).
+    ///     When <c>TEST_SDK_NETSTANDARD21</c> is defined, test data is resolved from the host output
+    ///     directory where <c>TestData</c> is copied at build time.
     /// </summary>
     /// <returns>The absolute path to the test project root directory.</returns>
     private static string GetTestProjectRoot()
     {
+#if TEST_SDK_NETSTANDARD21
+        return AppContext.BaseDirectory;
+#else
         var baseDir = AppContext.BaseDirectory;
         // Go up 4 levels: bin/Debug/net8.0 -> Debug -> bin -> StellarDotnetSdk.Tests
         for (var i = 0; i < 4; i++)
@@ -52,6 +59,23 @@ public static class Utils
         }
 
         return baseDir ?? ".";
+#endif
+    }
+
+    /// <summary>
+    ///     Maps a compiled test source file path to its directory relative to <see cref="SourceTestProjectName" />.
+    /// </summary>
+    private static string GetTestRelativeDirectoryFromSourcePath(string testFilePath)
+    {
+        var markerIndex = testFilePath.IndexOf(SourceTestProjectName, StringComparison.Ordinal);
+        if (markerIndex < 0)
+        {
+            return string.Empty;
+        }
+
+        var afterProject = testFilePath[(markerIndex + SourceTestProjectName.Length)..]
+            .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return Path.GetDirectoryName(afterProject) ?? string.Empty;
     }
 
     /// <summary>
@@ -87,6 +111,12 @@ public static class Utils
         {
             return Path.Combine("TestData", jsonFilePath);
         }
+
+#if TEST_SDK_NETSTANDARD21
+        // Source files are compiled from StellarDotnetSdk.Tests; TestData mirrors that tree under output.
+        var ns21RelativeDirectory = GetTestRelativeDirectoryFromSourcePath(testFilePath);
+        return Path.Combine("TestData", ns21RelativeDirectory, jsonFilePath);
+#else
         // testFilePath would be something like C:\workspace\dotnet-stellar-sdk\StellarDotnetSdk.Tests\Responses\Effects\LiquidityPoolEffectResponseTest.cs on Windows
         // testFileDirectoryPath would be something like C:\workspace\dotnet-stellar-sdk\StellarDotnetSdk.Tests\Responses\Effects\ on Windows
         // AppContext.BaseDirectory would be /home/runner/work/dotnet-stellar-sdk/dotnet-stellar-sdk/StellarDotnetSdk.Tests/bin/Release/net8.0 on Linux
@@ -99,6 +129,7 @@ public static class Utils
         var testRelativeDirectoryPath = Path.GetRelativePath(rootPath, testFileDirectoryPath);
 
         return Path.Combine("TestData", testRelativeDirectoryPath, jsonFilePath);
+#endif
     }
 
     public static TransactionResult AssertResultOfType(string xdr, Type resultType, bool isSuccess)

--- a/StellarDotnetSdk.Xdr/Compatibility/NetstandardCompat.cs
+++ b/StellarDotnetSdk.Xdr/Compatibility/NetstandardCompat.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace StellarDotnetSdk.Xdr.Compatibility;
+
+internal static class NetstandardCompat
+{
+    public static void AddRangeCompat(this List<byte> bytes, ReadOnlySpan<byte> buffer)
+    {
+#if NET8_0_OR_GREATER
+        bytes.AddRange(buffer);
+#else
+        // List<T>.AddRange(ReadOnlySpan<T>) is not available on netstandard2.1.
+        bytes.AddRange(buffer.ToArray());
+#endif
+    }
+
+    public static void ReadExactlyCompat(this Stream stream, Span<byte> buffer)
+    {
+#if NET8_0_OR_GREATER
+        stream.ReadExactly(buffer);
+#else
+        var totalRead = 0;
+        while (totalRead < buffer.Length)
+        {
+            var read = stream.Read(buffer.Slice(totalRead));
+            if (read <= 0)
+            {
+                throw new EndOfStreamException(
+                    $"Unable to read required number of bytes. Expected {buffer.Length}, got {totalRead}.");
+            }
+
+            totalRead += read;
+        }
+#endif
+    }
+
+    public static void ReadExactlyCompat(this Stream stream, byte[] buffer)
+    {
+        stream.ReadExactlyCompat(buffer.AsSpan());
+    }
+}
+

--- a/StellarDotnetSdk.Xdr/Compatibility/Throw.cs
+++ b/StellarDotnetSdk.Xdr/Compatibility/Throw.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace StellarDotnetSdk.Xdr.Compatibility;
+
+internal static class Throw
+{
+    public static void IfNull(object? value, string paramName)
+    {
+#if NETSTANDARD2_1
+        if (value == null)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+#else
+        ArgumentNullException.ThrowIfNull(value, paramName);
+#endif
+    }
+}

--- a/StellarDotnetSdk.Xdr/StellarDotnetSdk.Xdr.csproj
+++ b/StellarDotnetSdk.Xdr/StellarDotnetSdk.Xdr.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net10.0;net8.0;netstandard2.1</TargetFrameworks>
         <Version>10.0.0</Version>
         <OutputType>Library</OutputType>
         <StartupObject/>

--- a/StellarDotnetSdk.Xdr/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/XdrDataInputStream.cs
@@ -6,6 +6,7 @@ using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace StellarDotnetSdk.Xdr;
 
@@ -25,7 +26,7 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
-        ArgumentNullException.ThrowIfNull(bytes);
+        Throw.IfNull(bytes, nameof(bytes));
         _bytes = bytes;
         _stream = new MemoryStream(bytes, false);
     }
@@ -37,7 +38,7 @@ public class XdrDataInputStream
     public byte Read()
     {
         Span<byte> buffer = stackalloc byte[1];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return buffer[0];
     }
 
@@ -85,14 +86,14 @@ public class XdrDataInputStream
     internal long ReadLong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
@@ -103,7 +104,7 @@ public class XdrDataInputStream
     public int ReadInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
@@ -114,7 +115,7 @@ public class XdrDataInputStream
     public uint ReadUInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
@@ -221,7 +222,7 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        _stream.ReadExactly(result);
+        _stream.ReadExactlyCompat(result);
 
         if (tail == 0)
         {
@@ -229,7 +230,7 @@ public class XdrDataInputStream
         }
 
         var tailBytes = new byte[tailLength];
-        _stream.ReadExactly(tailBytes);
+        _stream.ReadExactlyCompat(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {

--- a/StellarDotnetSdk.Xdr/XdrDataOutputStream.cs
+++ b/StellarDotnetSdk.Xdr/XdrDataOutputStream.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace StellarDotnetSdk.Xdr;
 
@@ -69,28 +70,28 @@ public class XdrDataOutputStream
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
         BinaryPrimitives.WriteInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteULong(ulong v)
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
         BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteInt(int i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
         BinaryPrimitives.WriteInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteUInt(uint i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
         BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteSingle(float v)

--- a/StellarDotnetSdk.Xdr/xdr-generator/generator/templates/XdrDataInputStream.erb
+++ b/StellarDotnetSdk.Xdr/xdr-generator/generator/templates/XdrDataInputStream.erb
@@ -6,6 +6,7 @@ using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace <%= @namespace %>;
 
@@ -25,7 +26,7 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
-        ArgumentNullException.ThrowIfNull(bytes);
+        Throw.IfNull(bytes, nameof(bytes));
         _bytes = bytes;
         _stream = new MemoryStream(bytes, false);
     }
@@ -37,7 +38,7 @@ public class XdrDataInputStream
     public byte Read()
     {
         Span<byte> buffer = stackalloc byte[1];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return buffer[0];
     }
 
@@ -85,14 +86,14 @@ public class XdrDataInputStream
     internal long ReadLong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
@@ -103,7 +104,7 @@ public class XdrDataInputStream
     public int ReadInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
@@ -114,7 +115,7 @@ public class XdrDataInputStream
     public uint ReadUInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
@@ -221,7 +222,7 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        _stream.ReadExactly(result);
+        _stream.ReadExactlyCompat(result);
 
         if (tail == 0)
         {
@@ -229,7 +230,7 @@ public class XdrDataInputStream
         }
 
         var tailBytes = new byte[tailLength];
-        _stream.ReadExactly(tailBytes);
+        _stream.ReadExactlyCompat(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {

--- a/StellarDotnetSdk.Xdr/xdr-generator/generator/templates/XdrDataOutputStream.erb
+++ b/StellarDotnetSdk.Xdr/xdr-generator/generator/templates/XdrDataOutputStream.erb
@@ -5,6 +5,7 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace <%= @namespace %>;
 
@@ -69,28 +70,28 @@ public class XdrDataOutputStream
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
         BinaryPrimitives.WriteInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteULong(ulong v)
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
         BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteInt(int i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
         BinaryPrimitives.WriteInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteUInt(uint i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
         BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteSingle(float v)

--- a/StellarDotnetSdk/Accounts/KeyPair.cs
+++ b/StellarDotnetSdk/Accounts/KeyPair.cs
@@ -43,14 +43,17 @@ public class KeyPair : IAccountId, IEquatable<KeyPair>
     /// <param name="seed"></param>
     public KeyPair(byte[] publicKey, byte[]? privateKey, byte[]? seed)
     {
-        _publicKey = publicKey ?? throw new ArgumentNullException(nameof(publicKey));
-        SeedBytes = seed ?? privateKey;
+        if (publicKey == null) throw new ArgumentNullException(nameof(publicKey));
+
+        _publicKey = (byte[])publicKey.Clone();
+        var secret = seed ?? privateKey;
+        SeedBytes = secret != null ? (byte[])secret.Clone() : null;
     }
 
     /// <summary>
     ///     The private key.
     /// </summary>
-    public byte[]? PrivateKey => SeedBytes;
+    public byte[]? PrivateKey => SeedBytes is null ? null : (byte[])SeedBytes.Clone();
 
     /// <summary>
     ///     The bytes of the Secret Seed
@@ -124,7 +127,7 @@ public class KeyPair : IAccountId, IEquatable<KeyPair>
     /// <summary>
     ///     The public key.
     /// </summary>
-    public byte[] PublicKey => _publicKey;
+    public byte[] PublicKey => (byte[])_publicKey.Clone();
 
     /// <summary>
     ///     AccountId

--- a/StellarDotnetSdk/Accounts/KeyPair.cs
+++ b/StellarDotnetSdk/Accounts/KeyPair.cs
@@ -3,10 +3,9 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text.Json.Serialization;
 using dotnetstandard_bip32;
-using NSec.Cryptography;
+using StellarDotnetSdk.Crypto;
 using StellarDotnetSdk.Converters;
 using StellarDotnetSdk.Xdr;
-using PublicKey = NSec.Cryptography.PublicKey;
 using xdr_PublicKey = StellarDotnetSdk.Xdr.PublicKey;
 
 namespace StellarDotnetSdk.Accounts;
@@ -24,16 +23,7 @@ namespace StellarDotnetSdk.Accounts;
 [JsonConverter(typeof(KeyPairJsonConverter))]
 public class KeyPair : IAccountId, IEquatable<KeyPair>
 {
-    private readonly PublicKey _publicKey;
-
-    private readonly Key? _secretKey;
-
-    private KeyPair(Key secretKey, byte[] seed)
-    {
-        _secretKey = secretKey ?? throw new ArgumentNullException(nameof(secretKey));
-        _publicKey = secretKey.PublicKey;
-        SeedBytes = seed ?? throw new ArgumentNullException(nameof(seed));
-    }
+    private readonly byte[] _publicKey;
 
     /// <summary>
     ///     Creates a new Keypair object from public key.
@@ -53,26 +43,14 @@ public class KeyPair : IAccountId, IEquatable<KeyPair>
     /// <param name="seed"></param>
     public KeyPair(byte[] publicKey, byte[]? privateKey, byte[]? seed)
     {
-        _publicKey = NSec.Cryptography.PublicKey.Import(SignatureAlgorithm.Ed25519, publicKey,
-            KeyBlobFormat.RawPublicKey);
-
-        if (privateKey != null)
-        {
-            _secretKey = Key.Import(SignatureAlgorithm.Ed25519, privateKey, KeyBlobFormat.RawPrivateKey,
-                new KeyCreationParameters { ExportPolicy = KeyExportPolicies.AllowPlaintextExport });
-        }
-        else
-        {
-            _secretKey = null;
-        }
-
-        SeedBytes = seed;
+        _publicKey = publicKey ?? throw new ArgumentNullException(nameof(publicKey));
+        SeedBytes = seed ?? privateKey;
     }
 
     /// <summary>
     ///     The private key.
     /// </summary>
-    public byte[]? PrivateKey => _secretKey?.Export(KeyBlobFormat.RawPrivateKey);
+    public byte[]? PrivateKey => SeedBytes;
 
     /// <summary>
     ///     The bytes of the Secret Seed
@@ -146,7 +124,7 @@ public class KeyPair : IAccountId, IEquatable<KeyPair>
     /// <summary>
     ///     The public key.
     /// </summary>
-    public byte[] PublicKey => _publicKey.Export(KeyBlobFormat.RawPublicKey);
+    public byte[] PublicKey => _publicKey;
 
     /// <summary>
     ///     AccountId
@@ -210,7 +188,7 @@ public class KeyPair : IAccountId, IEquatable<KeyPair>
         {
             return false;
         }
-        return _publicKey.Equals(other._publicKey);
+        return _publicKey.SequenceEqual(other._publicKey);
     }
 
     /// <summary>
@@ -243,7 +221,7 @@ public class KeyPair : IAccountId, IEquatable<KeyPair>
     /// <returns></returns>
     public bool CanSign()
     {
-        return _secretKey != null;
+        return SeedBytes != null;
     }
 
     /// <summary>
@@ -268,10 +246,8 @@ public class KeyPair : IAccountId, IEquatable<KeyPair>
     /// </returns>
     public static KeyPair FromSecretSeed(byte[] seed)
     {
-        var privateKey = Key.Import(SignatureAlgorithm.Ed25519, seed, KeyBlobFormat.RawPrivateKey,
-            new KeyCreationParameters { ExportPolicy = KeyExportPolicies.AllowPlaintextExport });
-
-        return new KeyPair(privateKey, seed);
+        var publicKey = Ed25519.GetPublicKey(seed);
+        return new KeyPair(publicKey, privateKey: seed, seed: seed);
     }
 
     /// <summary>
@@ -349,13 +325,13 @@ public class KeyPair : IAccountId, IEquatable<KeyPair>
     /// <returns>signed bytes, null if the private key for this keypair is null.</returns>
     public byte[] Sign(byte[] data)
     {
-        if (_secretKey == null)
+        if (SeedBytes == null)
         {
             throw new Exception(
                 "KeyPair does not contain secret key. Use KeyPair.fromSecretSeed method to create a new KeyPair with a secret key.");
         }
 
-        return SignatureAlgorithm.Ed25519.Sign(_secretKey, data);
+        return Ed25519.Sign(SeedBytes, data);
     }
 
     /// <summary>
@@ -418,7 +394,7 @@ public class KeyPair : IAccountId, IEquatable<KeyPair>
     {
         try
         {
-            return SignatureAlgorithm.Ed25519.Verify(_publicKey, data, signature);
+            return Ed25519.Verify(_publicKey, data, signature);
         }
         catch
         {

--- a/StellarDotnetSdk/Accounts/KeyPair.cs
+++ b/StellarDotnetSdk/Accounts/KeyPair.cs
@@ -399,7 +399,7 @@ public class KeyPair : IAccountId, IEquatable<KeyPair>
         {
             return Ed25519.Verify(_publicKey, data, signature);
         }
-        catch
+        catch (Exception ex) when (ex is ArgumentException or FormatException or CryptographicException)
         {
             return false;
         }

--- a/StellarDotnetSdk/ClaimableBalanceIdUtils.cs
+++ b/StellarDotnetSdk/ClaimableBalanceIdUtils.cs
@@ -79,14 +79,14 @@ public static class ClaimableBalanceIdUtils
     {
         var os = new XdrDataOutputStream();
         ClaimableBalanceID.Encode(os, xdr);
-        return Convert.ToHexString(os.ToArray());
+        return Util.BytesToHex(os.ToArray());
     }
 
     internal static ClaimableBalanceID FromHexString(string hex)
     {
         try
         {
-            var inputStream = new XdrDataInputStream(Convert.FromHexString(hex));
+            var inputStream = new XdrDataInputStream(Util.HexToBytes(hex));
             return ClaimableBalanceID.Decode(inputStream);
         }
         catch

--- a/StellarDotnetSdk/Compatibility/CompilerPolyfills.cs
+++ b/StellarDotnetSdk/Compatibility/CompilerPolyfills.cs
@@ -1,0 +1,53 @@
+// Compiler polyfills required for netstandard2.1 builds.
+// These types are normally provided by newer runtimes / reference assemblies.
+
+#if NETSTANDARD2_1
+namespace System.Runtime.CompilerServices
+{
+    // Support for init-only setters (C# 9).
+    internal static class IsExternalInit
+    {
+    }
+
+    // Support for required members (C# 11).
+    [System.AttributeUsage(
+        System.AttributeTargets.Class |
+        System.AttributeTargets.Struct |
+        System.AttributeTargets.Field |
+        System.AttributeTargets.Property,
+        Inherited = false,
+        AllowMultiple = false)]
+    internal sealed class RequiredMemberAttribute : System.Attribute
+    {
+    }
+
+    // Used by the compiler to annotate features such as required members.
+    [System.AttributeUsage(
+        System.AttributeTargets.Class |
+        System.AttributeTargets.Struct |
+        System.AttributeTargets.Field |
+        System.AttributeTargets.Property,
+        Inherited = false,
+        AllowMultiple = true)]
+    internal sealed class CompilerFeatureRequiredAttribute : System.Attribute
+    {
+        public CompilerFeatureRequiredAttribute(string featureName)
+        {
+            FeatureName = featureName;
+        }
+
+        public string FeatureName { get; }
+
+        public bool IsOptional { get; set; }
+    }
+}
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    // Support for required members analysis (C# 11).
+    [System.AttributeUsage(System.AttributeTargets.Constructor, Inherited = false, AllowMultiple = false)]
+    internal sealed class SetsRequiredMembersAttribute : System.Attribute
+    {
+    }
+}
+#endif

--- a/StellarDotnetSdk/Compatibility/HttpContentExtensions.cs
+++ b/StellarDotnetSdk/Compatibility/HttpContentExtensions.cs
@@ -1,0 +1,17 @@
+#if NETSTANDARD2_1
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace StellarDotnetSdk.Compatibility;
+
+internal static class HttpContentExtensions
+{
+    public static async Task<string> ReadAsStringAsync(this HttpContent content, CancellationToken cancellationToken)
+    {
+        var result = await content.ReadAsStringAsync().ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        return result;
+    }
+}
+#endif

--- a/StellarDotnetSdk/Compatibility/HttpContentExtensions.cs
+++ b/StellarDotnetSdk/Compatibility/HttpContentExtensions.cs
@@ -9,9 +9,28 @@ internal static class HttpContentExtensions
 {
     public static async Task<string> ReadAsStringAsync(this HttpContent content, CancellationToken cancellationToken)
     {
-        var result = await content.ReadAsStringAsync().ConfigureAwait(false);
         cancellationToken.ThrowIfCancellationRequested();
-        return result;
+        if (!cancellationToken.CanBeCanceled)
+        {
+            return await content.ReadAsStringAsync().ConfigureAwait(false);
+        }
+
+        // HttpContent.ReadAsStringAsync() has no token overload before .NET 6, so race the read against
+        // a cancellation signal to avoid waiting for the full body when the caller cancels mid-read.
+        var readTask = content.ReadAsStringAsync();
+        var cancellationTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using (cancellationToken.Register(static state => ((TaskCompletionSource<bool>)state!).TrySetResult(true), cancellationTcs))
+        {
+            var completed = await Task.WhenAny(readTask, cancellationTcs.Task).ConfigureAwait(false);
+            if (completed != readTask)
+            {
+                // Observe the eventual read result/exception so it is not left unobserved.
+                _ = readTask.ContinueWith(static t => _ = t.Exception, TaskContinuationOptions.OnlyOnFaulted);
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+        }
+
+        return await readTask.ConfigureAwait(false);
     }
 }
 #endif

--- a/StellarDotnetSdk/Compatibility/Throw.cs
+++ b/StellarDotnetSdk/Compatibility/Throw.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace StellarDotnetSdk.Compatibility;
+
+internal static class Throw
+{
+    public static void IfNull(object? value, string paramName)
+    {
+#if NETSTANDARD2_1
+        if (value == null)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+#else
+        ArgumentNullException.ThrowIfNull(value, paramName);
+#endif
+    }
+
+    public static void IfNullOrEmpty(string? value, string paramName)
+    {
+#if NETSTANDARD2_1
+        if (value == null)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+
+        if (value.Length == 0)
+        {
+            throw new ArgumentException("Value cannot be empty.", paramName);
+        }
+#else
+        ArgumentException.ThrowIfNullOrEmpty(value, paramName);
+#endif
+    }
+}
+

--- a/StellarDotnetSdk/Compatibility/sep/SEP-0009_COMPATIBILITY_MATRIX.md
+++ b/StellarDotnetSdk/Compatibility/sep/SEP-0009_COMPATIBILITY_MATRIX.md
@@ -35,6 +35,14 @@ determined by the needs of the application.
 
 ✅ **Implemented**
 
+### Target-framework API notes
+
+SEP-0009 date fields keep the same JSON wire format (`yyyy-MM-dd`) across all target frameworks, but their public
+property types differ by TFM:
+
+- `net10.0` / `net8.0`: `DateOnly?`
+- `netstandard2.1`: `string?`
+
 ### Implementation Files
 
 - `StellarDotnetSdk/Sep/Sep0009/StandardKycFields.cs`
@@ -105,7 +113,7 @@ determined by the needs of the application.
 | `address` |  | ✅ | `Address` | Entire address (country, state, postal code, street address, etc.) as a multi-line string |
 | `address_country_code` |  | ✅ | `AddressCountryCode` | Country code for current address |
 | `birth_country_code` |  | ✅ | `BirthCountryCode` | ISO Code of country of birth (ISO 3166-1 alpha-3) |
-| `birth_date` |  | ✅ | `BirthDate` | Date of birth (e.g., 1976-07-04) |
+| `birth_date` |  | ✅ | `BirthDate` | Date of birth (e.g., 1976-07-04). `DateOnly?` on net8+/net10; `string?` on netstandard2.1 |
 | `birth_place` |  | ✅ | `BirthPlace` | Place of birth (city, state, country; as on passport) |
 | `city` |  | ✅ | `City` | Name of city/town |
 | `email_address` |  | ✅ | `EmailAddress` | Email address |
@@ -113,8 +121,8 @@ determined by the needs of the application.
 | `employer_name` |  | ✅ | `EmployerName` | Name of employer |
 | `first_name` |  | ✅ | `FirstName` | Given or first name |
 | `id_country_code` |  | ✅ | `IdCountryCode` | Country issuing passport or photo ID (ISO 3166-1 alpha-3) |
-| `id_expiration_date` |  | ✅ | `IdExpirationDate` | ID expiration date |
-| `id_issue_date` |  | ✅ | `IdIssueDate` | ID issue date |
+| `id_expiration_date` |  | ✅ | `IdExpirationDate` | ID expiration date. `DateOnly?` on net8+/net10; `string?` on netstandard2.1 |
+| `id_issue_date` |  | ✅ | `IdIssueDate` | ID issue date. `DateOnly?` on net8+/net10; `string?` on netstandard2.1 |
 | `id_number` |  | ✅ | `IdNumber` | Passport or ID number |
 | `id_type` |  | ✅ | `IdType` | Type of ID (passport, drivers_license, id_card, etc.) |
 | `ip_address` |  | ✅ | `IpAddress` | IP address of customer's computer |
@@ -152,7 +160,7 @@ determined by the needs of the application.
 | `organization.photo_proof_address` |  | ✅ | `PhotoProofAddress` | Image of a utility bill, bank statement with the organization's name and address |
 | `organization.postal_code` |  | ✅ | `PostalCode` | Postal or other code identifying organization's locale |
 | `organization.registered_address` |  | ✅ | `RegisteredAddress` | Organization registered address |
-| `organization.registration_date` |  | ✅ | `RegistrationDate` | Date the organization was registered |
+| `organization.registration_date` |  | ✅ | `RegistrationDate` | Date the organization was registered. `DateOnly?` on net8+/net10; `string?` on netstandard2.1 |
 | `organization.registration_number` |  | ✅ | `RegistrationNumber` | Organization registration number |
 | `organization.shareholder_name` |  | ✅ | `ShareholderName` | Name of shareholder (can be organization or person) |
 | `organization.state_or_province` |  | ✅ | `StateOrProvince` | Name of state/province/region/prefecture |

--- a/StellarDotnetSdk/CompatibilitySuppressions.xml
+++ b/StellarDotnetSdk/CompatibilitySuppressions.xml
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:StellarDotnetSdk.Sep.Sep0009.NaturalPersonKycFields.get_BirthDate</Target>
+    <Left>lib/netstandard2.1/StellarDotnetSdk.dll</Left>
+    <Right>lib/net8.0/StellarDotnetSdk.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:StellarDotnetSdk.Sep.Sep0009.NaturalPersonKycFields.get_IdExpirationDate</Target>
+    <Left>lib/netstandard2.1/StellarDotnetSdk.dll</Left>
+    <Right>lib/net8.0/StellarDotnetSdk.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:StellarDotnetSdk.Sep.Sep0009.NaturalPersonKycFields.get_IdIssueDate</Target>
+    <Left>lib/netstandard2.1/StellarDotnetSdk.dll</Left>
+    <Right>lib/net8.0/StellarDotnetSdk.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:StellarDotnetSdk.Sep.Sep0009.OrganizationKycFields.get_RegistrationDate</Target>
+    <Left>lib/netstandard2.1/StellarDotnetSdk.dll</Left>
+    <Right>lib/net8.0/StellarDotnetSdk.dll</Right>
+  </Suppression>
+</Suppressions>

--- a/StellarDotnetSdk/Converters/DateOnlyJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/DateOnlyJsonConverter.cs
@@ -1,0 +1,34 @@
+#if !NETSTANDARD2_1
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace StellarDotnetSdk.Converters;
+
+/// <summary>
+///     Serializes <see cref="DateOnly" /> as ISO 8601 date-only strings (yyyy-MM-dd), matching SEP-0009.
+/// </summary>
+public class DateOnlyJsonConverter : JsonConverter<DateOnly>
+{
+    internal const string IsoDateFormat = "yyyy-MM-dd";
+
+    /// <inheritdoc />
+    public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        if (value is null)
+        {
+            throw new JsonException("Cannot convert null JSON value to DateOnly.");
+        }
+
+        return DateOnly.ParseExact(value, IsoDateFormat, CultureInfo.InvariantCulture);
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, DateOnly value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString(IsoDateFormat, CultureInfo.InvariantCulture));
+    }
+}
+#endif

--- a/StellarDotnetSdk/Converters/DateOnlyJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/DateOnlyJsonConverter.cs
@@ -22,7 +22,12 @@ public class DateOnlyJsonConverter : JsonConverter<DateOnly>
             throw new JsonException("Cannot convert null JSON value to DateOnly.");
         }
 
-        return DateOnly.ParseExact(value, IsoDateFormat, CultureInfo.InvariantCulture);
+        if (!DateOnly.TryParseExact(value, IsoDateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out var result))
+        {
+            throw new JsonException($"Cannot convert JSON value '{value}' to DateOnly. Expected format: {IsoDateFormat}.");
+        }
+
+        return result;
     }
 
     /// <inheritdoc />

--- a/StellarDotnetSdk/Converters/EffectResponseJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/EffectResponseJsonConverter.cs
@@ -1,5 +1,7 @@
 using System;
+#if NET8_0_OR_GREATER
 using System.Collections.Frozen;
+#endif
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -48,7 +50,7 @@ public class EffectResponseJsonConverter : JsonConverter<EffectResponse>
     ///     Frozen lookup table mapping <c>type_i</c> discriminator values to concrete-type deserializers.
     ///     Built once at type initialization for optimal read performance across 40+ non-sequential keys.
     /// </summary>
-    private static readonly FrozenDictionary<int, Func<JsonElement, JsonSerializerOptions, EffectResponse?>>
+    private static readonly IReadOnlyDictionary<int, Func<JsonElement, JsonSerializerOptions, EffectResponse?>>
         Deserializers =
             new Dictionary<int, Func<JsonElement, JsonSerializerOptions, EffectResponse?>>
             {
@@ -111,7 +113,12 @@ public class EffectResponseJsonConverter : JsonConverter<EffectResponse>
                 [95] = static (root, options) => root.Deserialize<LiquidityPoolRevokedEffectResponse>(options),
                 [96] = static (root, options) => root.Deserialize<ContractCreditedEffectResponse>(options),
                 [97] = static (root, options) => root.Deserialize<ContractDebitedEffectResponse>(options),
-            }.ToFrozenDictionary();
+            }
+#if NET8_0_OR_GREATER
+            .ToFrozenDictionary();
+#else
+            ;
+#endif
 
     /// <inheritdoc />
     public override bool CanConvert(Type typeToConvert)

--- a/StellarDotnetSdk/Converters/JsonOptions.cs
+++ b/StellarDotnetSdk/Converters/JsonOptions.cs
@@ -48,10 +48,14 @@ public static class JsonOptions
             // Reject JSON payloads with duplicate property names to prevent silent data corruption.
             // Malformed or adversarial responses could otherwise overwrite financial fields (amount,
             // balance, destination) with attacker-controlled values without any error.
+#if NET10_0_OR_GREATER
             AllowDuplicateProperties = false,
+#endif
 
+#if NET10_0_OR_GREATER
             // Enforce C# nullability annotations so null values for non-nullable properties are rejected
             RespectNullableAnnotations = true,
+#endif
 
             Converters =
             {

--- a/StellarDotnetSdk/Converters/JsonOptions.cs
+++ b/StellarDotnetSdk/Converters/JsonOptions.cs
@@ -20,9 +20,10 @@ public static class JsonOptions
     ///     Configuration:
     ///     - NumberHandling: Allows reading numbers from strings (API compatibility)
     ///     - PropertyNameCaseInsensitive: Allows flexible property matching
-    ///     - AllowDuplicateProperties: Rejects JSON payloads that contain the same property more than once,
+    ///     - AllowDuplicateProperties (net10.0+ only): Rejects JSON payloads that contain the same property more than once,
     ///     preventing silent data corruption from malformed responses (critical for financial data integrity).
-    ///     - RespectNullableAnnotations: Enforces C# nullability annotations during (de)serialization,
+    ///     On net8.0/netstandard2.1 this option is unavailable; STJ uses its default duplicate-property behavior.
+    ///     - RespectNullableAnnotations (net10.0+ only): Enforces C# nullability annotations during (de)serialization,
     ///     so malformed API responses that violate the SDK's nullability contract fail fast.
     ///     Registered Converters:
     ///     - Polymorphic converters: OperationResponse, EffectResponse, Predicate
@@ -45,15 +46,18 @@ public static class JsonOptions
             // Case-insensitive property matching
             PropertyNameCaseInsensitive = true,
 
-            // Reject JSON payloads with duplicate property names to prevent silent data corruption.
-            // Malformed or adversarial responses could otherwise overwrite financial fields (amount,
-            // balance, destination) with attacker-controlled values without any error.
+            // AllowDuplicateProperties (net10.0+ only): Reject JSON payloads with duplicate property names to prevent
+            // silent data corruption. Malformed or adversarial responses could otherwise overwrite financial fields
+            // (amount, balance, destination) with attacker-controlled values without any error.
+            // On net8.0/netstandard2.1 this STJ option is unavailable; deserialization uses the runtime default
+            // (last duplicate property wins).
 #if NET10_0_OR_GREATER
             AllowDuplicateProperties = false,
 #endif
 
 #if NET10_0_OR_GREATER
-            // Enforce C# nullability annotations so null values for non-nullable properties are rejected
+            // RespectNullableAnnotations (net10.0+ only): Enforce C# nullability annotations so null values for
+            // non-nullable properties are rejected during deserialization.
             RespectNullableAnnotations = true,
 #endif
 
@@ -86,9 +90,8 @@ public static class JsonOptions
         // Freeze the options to prevent accidental modification of the shared singleton.
         // populateMissingResolver: true installs the default reflection-based TypeInfoResolver,
         // which matches the SDK's existing serialization behavior.
-#if NET8_0_OR_GREATER
+        // STJ 8.0+ (including netstandard2.1 via package 8.0.5) provides MakeReadOnly(bool).
         options.MakeReadOnly(true);
-#endif
         return options;
     }
 }

--- a/StellarDotnetSdk/Converters/JsonOptions.cs
+++ b/StellarDotnetSdk/Converters/JsonOptions.cs
@@ -82,7 +82,9 @@ public static class JsonOptions
         // Freeze the options to prevent accidental modification of the shared singleton.
         // populateMissingResolver: true installs the default reflection-based TypeInfoResolver,
         // which matches the SDK's existing serialization behavior.
+#if NET8_0_OR_GREATER
         options.MakeReadOnly(true);
+#endif
         return options;
     }
 }

--- a/StellarDotnetSdk/Converters/LiquidityPoolTypeEnumJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/LiquidityPoolTypeEnumJsonConverter.cs
@@ -1,5 +1,7 @@
 using System;
+#if NET8_0_OR_GREATER
 using System.Collections.Frozen;
+#endif
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -22,21 +24,31 @@ public class LiquidityPoolTypeEnumJsonConverter : JsonConverter<LiquidityPoolTyp
     ///     <see cref="LiquidityPoolType.LiquidityPoolTypeEnum" />
     ///     values.
     /// </summary>
-    private static readonly FrozenDictionary<string, LiquidityPoolType.LiquidityPoolTypeEnum> EnumByName =
+    private static readonly IReadOnlyDictionary<string, LiquidityPoolType.LiquidityPoolTypeEnum> EnumByName =
         new Dictionary<string, LiquidityPoolType.LiquidityPoolTypeEnum>(StringComparer.Ordinal)
         {
             ["constant_product"] = LiquidityPoolType.LiquidityPoolTypeEnum.LIQUIDITY_POOL_CONSTANT_PRODUCT,
-        }.ToFrozenDictionary(StringComparer.Ordinal);
+        }
+#if NET8_0_OR_GREATER
+        .ToFrozenDictionary(StringComparer.Ordinal);
+#else
+        ;
+#endif
 
     /// <summary>
     ///     Frozen reverse lookup table mapping <see cref="LiquidityPoolType.LiquidityPoolTypeEnum" /> values to their
     ///     Horizon wire-format strings.
     /// </summary>
-    private static readonly FrozenDictionary<LiquidityPoolType.LiquidityPoolTypeEnum, string> NameByEnum =
+    private static readonly IReadOnlyDictionary<LiquidityPoolType.LiquidityPoolTypeEnum, string> NameByEnum =
         new Dictionary<LiquidityPoolType.LiquidityPoolTypeEnum, string>
         {
             [LiquidityPoolType.LiquidityPoolTypeEnum.LIQUIDITY_POOL_CONSTANT_PRODUCT] = "constant_product",
-        }.ToFrozenDictionary();
+        }
+#if NET8_0_OR_GREATER
+        .ToFrozenDictionary();
+#else
+        ;
+#endif
 
     /// <inheritdoc />
     public override LiquidityPoolType.LiquidityPoolTypeEnum Read(ref Utf8JsonReader reader, Type typeToConvert,

--- a/StellarDotnetSdk/Converters/NullableDateOnlyJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/NullableDateOnlyJsonConverter.cs
@@ -25,7 +25,13 @@ public class NullableDateOnlyJsonConverter : JsonConverter<DateOnly?>
             return null;
         }
 
-        return DateOnly.ParseExact(value, DateOnlyJsonConverter.IsoDateFormat, CultureInfo.InvariantCulture);
+        if (!DateOnly.TryParseExact(value, DateOnlyJsonConverter.IsoDateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out var result))
+        {
+            throw new JsonException(
+                $"Cannot convert JSON value '{value}' to DateOnly. Expected format: {DateOnlyJsonConverter.IsoDateFormat}.");
+        }
+
+        return result;
     }
 
     /// <inheritdoc />

--- a/StellarDotnetSdk/Converters/NullableDateOnlyJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/NullableDateOnlyJsonConverter.cs
@@ -1,0 +1,43 @@
+#if !NETSTANDARD2_1
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace StellarDotnetSdk.Converters;
+
+/// <summary>
+///     Serializes nullable <see cref="DateOnly" /> as ISO 8601 date-only strings (yyyy-MM-dd), matching SEP-0009.
+/// </summary>
+public class NullableDateOnlyJsonConverter : JsonConverter<DateOnly?>
+{
+    /// <inheritdoc />
+    public override DateOnly? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return null;
+        }
+
+        var value = reader.GetString();
+        if (value is null)
+        {
+            return null;
+        }
+
+        return DateOnly.ParseExact(value, DateOnlyJsonConverter.IsoDateFormat, CultureInfo.InvariantCulture);
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, DateOnly? value, JsonSerializerOptions options)
+    {
+        if (!value.HasValue)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        writer.WriteStringValue(value.Value.ToString(DateOnlyJsonConverter.IsoDateFormat, CultureInfo.InvariantCulture));
+    }
+}
+#endif

--- a/StellarDotnetSdk/Converters/OperationResponseJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/OperationResponseJsonConverter.cs
@@ -1,5 +1,7 @@
 using System;
+#if NET8_0_OR_GREATER
 using System.Collections.Frozen;
+#endif
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -40,7 +42,7 @@ public class OperationResponseJsonConverter : JsonConverter<OperationResponse>
     ///     Frozen lookup table mapping <c>type_i</c> discriminator values to concrete-type deserializers.
     ///     Built once at type initialization for optimal read performance.
     /// </summary>
-    private static readonly FrozenDictionary<int, Func<JsonElement, JsonSerializerOptions, OperationResponse?>>
+    private static readonly IReadOnlyDictionary<int, Func<JsonElement, JsonSerializerOptions, OperationResponse?>>
         Deserializers =
             new Dictionary<int, Func<JsonElement, JsonSerializerOptions, OperationResponse?>>
             {
@@ -73,7 +75,12 @@ public class OperationResponseJsonConverter : JsonConverter<OperationResponse>
                 [24] = static (root, options) => root.Deserialize<InvokeHostFunctionOperationResponse>(options),
                 [25] = static (root, options) => root.Deserialize<ExtendFootprintOperationResponse>(options),
                 [26] = static (root, options) => root.Deserialize<RestoreFootprintOperationResponse>(options),
-            }.ToFrozenDictionary();
+            }
+#if NET8_0_OR_GREATER
+            .ToFrozenDictionary();
+#else
+            ;
+#endif
 
     /// <inheritdoc />
     public override bool CanConvert(Type typeToConvert)

--- a/StellarDotnetSdk/Converters/SendTransactionStatusEnumJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/SendTransactionStatusEnumJsonConverter.cs
@@ -1,5 +1,7 @@
 using System;
+#if NET8_0_OR_GREATER
 using System.Collections.Frozen;
+#endif
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -20,14 +22,19 @@ public class SendTransactionStatusEnumJsonConverter : JsonConverter<SendTransact
     /// <summary>
     ///     Frozen lookup table mapping the Soroban RPC wire-format status strings to enum values.
     /// </summary>
-    private static readonly FrozenDictionary<string, SendTransactionResponse.SendTransactionStatus> StatusByName =
+    private static readonly IReadOnlyDictionary<string, SendTransactionResponse.SendTransactionStatus> StatusByName =
         new Dictionary<string, SendTransactionResponse.SendTransactionStatus>(StringComparer.Ordinal)
         {
             ["PENDING"] = SendTransactionResponse.SendTransactionStatus.PENDING,
             ["TRY_AGAIN_LATER"] = SendTransactionResponse.SendTransactionStatus.TRY_AGAIN_LATER,
             ["DUPLICATE"] = SendTransactionResponse.SendTransactionStatus.DUPLICATE,
             ["ERROR"] = SendTransactionResponse.SendTransactionStatus.ERROR,
-        }.ToFrozenDictionary(StringComparer.Ordinal);
+        }
+#if NET8_0_OR_GREATER
+        .ToFrozenDictionary(StringComparer.Ordinal);
+#else
+        ;
+#endif
 
     /// <inheritdoc />
     public override SendTransactionResponse.SendTransactionStatus Read(ref Utf8JsonReader reader, Type typeToConvert,

--- a/StellarDotnetSdk/Crypto/Ed25519.cs
+++ b/StellarDotnetSdk/Crypto/Ed25519.cs
@@ -1,0 +1,73 @@
+using System;
+using StellarDotnetSdk.Compatibility;
+
+namespace StellarDotnetSdk.Crypto;
+
+internal static class Ed25519
+{
+    public const int SeedLength = 32;
+    public const int PublicKeyLength = 32;
+
+    public static byte[] GetPublicKey(byte[] seed)
+    {
+        Throw.IfNull(seed, nameof(seed));
+        if (seed.Length != SeedLength) throw new ArgumentException($"Seed must be {SeedLength} bytes.", nameof(seed));
+
+#if NETSTANDARD2_1
+        var kp = Sodium.PublicKeyAuth.GenerateKeyPair(seed);
+        return kp.PublicKey;
+#else
+        var key = NSec.Cryptography.Key.Import(
+            NSec.Cryptography.SignatureAlgorithm.Ed25519,
+            seed,
+            NSec.Cryptography.KeyBlobFormat.RawPrivateKey,
+            new NSec.Cryptography.KeyCreationParameters
+            {
+                ExportPolicy = NSec.Cryptography.KeyExportPolicies.AllowPlaintextExport,
+            });
+        return key.PublicKey.Export(NSec.Cryptography.KeyBlobFormat.RawPublicKey);
+#endif
+    }
+
+    public static byte[] Sign(byte[] seed, byte[] data)
+    {
+        Throw.IfNull(seed, nameof(seed));
+        if (seed.Length != SeedLength) throw new ArgumentException($"Seed must be {SeedLength} bytes.", nameof(seed));
+        Throw.IfNull(data, nameof(data));
+
+#if NETSTANDARD2_1
+        var kp = Sodium.PublicKeyAuth.GenerateKeyPair(seed);
+        return Sodium.PublicKeyAuth.SignDetached(data, kp.PrivateKey);
+#else
+        var key = NSec.Cryptography.Key.Import(
+            NSec.Cryptography.SignatureAlgorithm.Ed25519,
+            seed,
+            NSec.Cryptography.KeyBlobFormat.RawPrivateKey,
+            new NSec.Cryptography.KeyCreationParameters
+            {
+                ExportPolicy = NSec.Cryptography.KeyExportPolicies.AllowPlaintextExport,
+            });
+        return NSec.Cryptography.SignatureAlgorithm.Ed25519.Sign(key, data);
+#endif
+    }
+
+    public static bool Verify(byte[] publicKey, byte[] data, byte[] signature)
+    {
+        Throw.IfNull(publicKey, nameof(publicKey));
+        if (publicKey.Length != PublicKeyLength)
+            throw new ArgumentException($"PublicKey must be {PublicKeyLength} bytes.", nameof(publicKey));
+        Throw.IfNull(data, nameof(data));
+        Throw.IfNull(signature, nameof(signature));
+
+#if NETSTANDARD2_1
+        return Sodium.PublicKeyAuth.VerifyDetached(signature, data, publicKey);
+#else
+        var pk = NSec.Cryptography.PublicKey.Import(
+            NSec.Cryptography.SignatureAlgorithm.Ed25519,
+            publicKey,
+            NSec.Cryptography.KeyBlobFormat.RawPublicKey);
+        return NSec.Cryptography.SignatureAlgorithm.Ed25519.Verify(pk, data, signature);
+#endif
+    }
+}
+

--- a/StellarDotnetSdk/Crypto/Ed25519.cs
+++ b/StellarDotnetSdk/Crypto/Ed25519.cs
@@ -17,7 +17,7 @@ internal static class Ed25519
         var kp = Sodium.PublicKeyAuth.GenerateKeyPair(seed);
         return kp.PublicKey;
 #else
-        var key = NSec.Cryptography.Key.Import(
+        using var key = NSec.Cryptography.Key.Import(
             NSec.Cryptography.SignatureAlgorithm.Ed25519,
             seed,
             NSec.Cryptography.KeyBlobFormat.RawPrivateKey,
@@ -39,7 +39,7 @@ internal static class Ed25519
         var kp = Sodium.PublicKeyAuth.GenerateKeyPair(seed);
         return Sodium.PublicKeyAuth.SignDetached(data, kp.PrivateKey);
 #else
-        var key = NSec.Cryptography.Key.Import(
+        using var key = NSec.Cryptography.Key.Import(
             NSec.Cryptography.SignatureAlgorithm.Ed25519,
             seed,
             NSec.Cryptography.KeyBlobFormat.RawPrivateKey,

--- a/StellarDotnetSdk/LedgerKeys/LedgerKeyContractCode.cs
+++ b/StellarDotnetSdk/LedgerKeys/LedgerKeyContractCode.cs
@@ -14,7 +14,7 @@ public class LedgerKeyContractCode : LedgerKey
     ///     Use this to fetch contract wasm byte-code.
     /// </summary>
     /// <param name="wasmHash">A hex-encoded string of the Wasm bytes of a compiled smart contract.</param>
-    public LedgerKeyContractCode(string wasmHash) : this(Convert.FromHexString(wasmHash))
+    public LedgerKeyContractCode(string wasmHash) : this(Util.HexToBytes(wasmHash))
     {
     }
 
@@ -58,6 +58,6 @@ public class LedgerKeyContractCode : LedgerKey
     /// <param name="xdr">The XDR ledger key contract code object.</param>
     public static LedgerKeyContractCode FromXdr(Xdr.LedgerKey.LedgerKeyContractCode xdr)
     {
-        return new LedgerKeyContractCode(Convert.ToHexString(xdr.Hash.InnerValue));
+        return new LedgerKeyContractCode(Util.BytesToHex(xdr.Hash.InnerValue));
     }
 }

--- a/StellarDotnetSdk/Operations/SorobanAuthorization.cs
+++ b/StellarDotnetSdk/Operations/SorobanAuthorization.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using StellarDotnetSdk.Accounts;
+using StellarDotnetSdk.Compatibility;
 using StellarDotnetSdk.Soroban;
 using StellarDotnetSdk.Xdr;
 using EnvelopeTypeEnum = StellarDotnetSdk.Xdr.EnvelopeType.EnvelopeTypeEnum;
@@ -134,8 +135,8 @@ public static class SorobanAuthorization
         uint signatureExpirationLedger,
         SorobanAuthorizedInvocation invocation)
     {
-        ArgumentNullException.ThrowIfNull(network);
-        ArgumentNullException.ThrowIfNull(invocation);
+        Throw.IfNull(network, nameof(network));
+        Throw.IfNull(invocation, nameof(invocation));
 
         var preimage = new HashIDPreimage
         {
@@ -172,9 +173,9 @@ public static class SorobanAuthorization
         uint signatureExpirationLedger,
         SorobanAuthorizedInvocation invocation)
     {
-        ArgumentNullException.ThrowIfNull(network);
-        ArgumentNullException.ThrowIfNull(address);
-        ArgumentNullException.ThrowIfNull(invocation);
+        Throw.IfNull(network, nameof(network));
+        Throw.IfNull(address, nameof(address));
+        Throw.IfNull(invocation, nameof(invocation));
 
         var preimage = new HashIDPreimage
         {
@@ -224,8 +225,8 @@ public static class SorobanAuthorization
         uint validUntilLedgerSeq,
         Network network)
     {
-        ArgumentNullException.ThrowIfNull(entry);
-        ArgumentNullException.ThrowIfNull(network);
+        Throw.IfNull(entry, nameof(entry));
+        Throw.IfNull(network, nameof(network));
 
         return entry.Credentials switch
         {
@@ -284,7 +285,7 @@ public static class SorobanAuthorization
         SorobanCredentialsVersion version = SorobanCredentialsVersion.Preserve,
         ScAddress? forAddress = null)
     {
-        ArgumentNullException.ThrowIfNull(signer);
+        Throw.IfNull(signer, nameof(signer));
 
         return AuthorizeEntry(entry, new KeyPairEntrySigner(signer), validUntilLedgerSeq, network, version,
             forAddress);
@@ -363,9 +364,9 @@ public static class SorobanAuthorization
         SorobanCredentialsVersion version = SorobanCredentialsVersion.Preserve,
         ScAddress? forAddress = null)
     {
-        ArgumentNullException.ThrowIfNull(entry);
-        ArgumentNullException.ThrowIfNull(signer);
-        ArgumentNullException.ThrowIfNull(network);
+        Throw.IfNull(entry, nameof(entry));
+        Throw.IfNull(signer, nameof(signer));
+        Throw.IfNull(network, nameof(network));
 
         return entry.Credentials switch
         {
@@ -652,10 +653,10 @@ public static class SorobanAuthorization
         SorobanAuthorizationEntry entry, ISorobanEntrySigner rootSigner,
         IReadOnlyList<ISorobanEntrySigner> delegateSigners, uint validUntilLedgerSeq, Network network)
     {
-        ArgumentNullException.ThrowIfNull(entry);
-        ArgumentNullException.ThrowIfNull(rootSigner);
-        ArgumentNullException.ThrowIfNull(delegateSigners);
-        ArgumentNullException.ThrowIfNull(network);
+        Throw.IfNull(entry, nameof(entry));
+        Throw.IfNull(rootSigner, nameof(rootSigner));
+        Throw.IfNull(delegateSigners, nameof(delegateSigners));
+        Throw.IfNull(network, nameof(network));
 
         // Mirror BuildWithDelegatesEntry: an already-delegated entry is not a valid input here. Sign
         // such an entry incrementally with AuthorizeEntry(..., forAddress) instead.
@@ -768,8 +769,8 @@ public static class SorobanAuthorization
         IReadOnlyList<ScAddress> delegateAddresses,
         uint validUntilLedgerSeq)
     {
-        ArgumentNullException.ThrowIfNull(entry);
-        ArgumentNullException.ThrowIfNull(delegateAddresses);
+        Throw.IfNull(entry, nameof(entry));
+        Throw.IfNull(delegateAddresses, nameof(delegateAddresses));
 
         var (rootAddress, rootNonce) = entry.Credentials switch
         {

--- a/StellarDotnetSdk/Requests/DefaultStellarSdkHttpClient.cs
+++ b/StellarDotnetSdk/Requests/DefaultStellarSdkHttpClient.cs
@@ -70,7 +70,20 @@ public class DefaultStellarSdkHttpClient : HttpClient
         HttpResilienceOptions? resilienceOptions,
         HttpMessageHandler? innerHandler)
     {
-        var handler = innerHandler ?? new SocketsHttpHandler();
+        HttpMessageHandler handler;
+        if (innerHandler != null)
+        {
+            handler = innerHandler;
+        }
+        else
+        {
+#if NET8_0_OR_GREATER
+            handler = new SocketsHttpHandler();
+#else
+            // SocketsHttpHandler is not available on netstandard2.1 reference assemblies.
+            handler = new HttpClientHandler();
+#endif
+        }
 
         // Add resilience handler if any resilience feature is enabled (retries, circuit breaker, or
         // timeout). Status codes alone enable nothing — see HasAnyResilienceFeatureEnabled's remarks.

--- a/StellarDotnetSdk/Requests/EffectsRequestBuilder.cs
+++ b/StellarDotnetSdk/Requests/EffectsRequestBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using StellarDotnetSdk.Compatibility;
 using StellarDotnetSdk.LiquidityPool;
 using StellarDotnetSdk.Responses.Effects;
 
@@ -28,7 +29,7 @@ public class EffectsRequestBuilder : RequestBuilderStreamable<EffectsRequestBuil
     /// <param name="account">Account for which to get effects</param>
     public EffectsRequestBuilder ForAccount(string account)
     {
-        ArgumentException.ThrowIfNullOrEmpty(account);
+        Throw.IfNullOrEmpty(account, nameof(account));
 
         if (!StrKey.IsValidEd25519PublicKey(account))
         {
@@ -56,7 +57,7 @@ public class EffectsRequestBuilder : RequestBuilderStreamable<EffectsRequestBuil
     /// <param name="transactionId">Transaction ID for which to get effects</param>
     public EffectsRequestBuilder ForTransaction(string transactionId)
     {
-        ArgumentException.ThrowIfNullOrEmpty(transactionId);
+        Throw.IfNullOrEmpty(transactionId, nameof(transactionId));
 
         SetSegments("transactions", transactionId, "effects");
         return this;
@@ -90,7 +91,7 @@ public class EffectsRequestBuilder : RequestBuilderStreamable<EffectsRequestBuil
     /// <returns>The current <see cref="EffectsRequestBuilder" /> instance for chaining.</returns>
     public EffectsRequestBuilder ForLiquidityPool(string liquidityPoolId)
     {
-        ArgumentException.ThrowIfNullOrEmpty(liquidityPoolId);
+        Throw.IfNullOrEmpty(liquidityPoolId, nameof(liquidityPoolId));
 
         SetSegments("liquidity_pools", liquidityPoolId, "effects");
         return this;

--- a/StellarDotnetSdk/Requests/OffersRequestBuilder.cs
+++ b/StellarDotnetSdk/Requests/OffersRequestBuilder.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using StellarDotnetSdk.Assets;
+using StellarDotnetSdk.Compatibility;
 using StellarDotnetSdk.Responses;
 
 namespace StellarDotnetSdk.Requests;
@@ -51,7 +52,7 @@ public class OffersRequestBuilder : RequestBuilderExecutePageable<OffersRequestB
     /// <exception cref="ArgumentNullException"></exception>
     public OffersRequestBuilder Offers(OffersRequestOptions options)
     {
-        ArgumentNullException.ThrowIfNull(options);
+        Throw.IfNull(options, nameof(options));
 
         if (options.Seller != null)
         {
@@ -79,7 +80,7 @@ public class OffersRequestBuilder : RequestBuilderExecutePageable<OffersRequestB
     /// <exception cref="ArgumentNullException">Thrown when <c>optionsAction</c> is null.</exception>
     public OffersRequestBuilder Offers(Action<OffersRequestOptions> optionsAction)
     {
-        ArgumentNullException.ThrowIfNull(optionsAction);
+        Throw.IfNull(optionsAction, nameof(optionsAction));
 
         var options = new OffersRequestOptions();
         optionsAction.Invoke(options);

--- a/StellarDotnetSdk/Requests/OperationsRequestBuilder.cs
+++ b/StellarDotnetSdk/Requests/OperationsRequestBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using StellarDotnetSdk.Compatibility;
 using StellarDotnetSdk.Responses.Operations;
 
 namespace StellarDotnetSdk.Requests;
@@ -53,7 +54,7 @@ public class OperationsRequestBuilder : RequestBuilderStreamable<OperationsReque
     /// <param name="account">Account for which to get operations</param>
     public OperationsRequestBuilder ForAccount(string account)
     {
-        ArgumentException.ThrowIfNullOrEmpty(account);
+        Throw.IfNullOrEmpty(account, nameof(account));
 
         if (!StrKey.IsValidEd25519PublicKey(account))
         {
@@ -72,7 +73,7 @@ public class OperationsRequestBuilder : RequestBuilderStreamable<OperationsReque
     /// <param name="claimableBalanceId">Hex-encoded claimable balance ID (0000...) for which to get operations.</param>
     public OperationsRequestBuilder ForClaimableBalance(string claimableBalanceId)
     {
-        ArgumentException.ThrowIfNullOrEmpty(claimableBalanceId);
+        Throw.IfNullOrEmpty(claimableBalanceId, nameof(claimableBalanceId));
         if (!StrKey.IsValidClaimableBalanceId(ClaimableBalanceIdUtils.ToBase32String(claimableBalanceId)))
         {
             throw new ArgumentException($"Claimable balance ID {claimableBalanceId} is not valid.");
@@ -111,7 +112,7 @@ public class OperationsRequestBuilder : RequestBuilderStreamable<OperationsReque
     /// <param name="transactionId">Transaction ID for which to get operations</param>
     public OperationsRequestBuilder ForTransaction(string transactionId)
     {
-        ArgumentException.ThrowIfNullOrEmpty(transactionId);
+        Throw.IfNullOrEmpty(transactionId, nameof(transactionId));
 
         SetSegments("transactions", transactionId, "operations");
 
@@ -125,7 +126,7 @@ public class OperationsRequestBuilder : RequestBuilderStreamable<OperationsReque
     /// <param name="liquidityPoolId">Liquidity pool ID for which to get operations</param>
     public OperationsRequestBuilder ForLiquidityPool(string liquidityPoolId)
     {
-        ArgumentException.ThrowIfNullOrEmpty(liquidityPoolId);
+        Throw.IfNullOrEmpty(liquidityPoolId, nameof(liquidityPoolId));
 
         SetSegments("liquidity_pools", liquidityPoolId, "operations");
 

--- a/StellarDotnetSdk/Requests/PathsRequestBuilder.cs
+++ b/StellarDotnetSdk/Requests/PathsRequestBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using StellarDotnetSdk.Assets;
+using StellarDotnetSdk.Compatibility;
 using StellarDotnetSdk.Responses;
 
 namespace StellarDotnetSdk.Requests;
@@ -28,7 +29,7 @@ public class PathsRequestBuilder : RequestBuilderExecutePageable<PathsRequestBui
     /// <exception cref="ArgumentException">Thrown when the account ID is invalid.</exception>
     public PathsRequestBuilder DestinationAccount(string account)
     {
-        ArgumentException.ThrowIfNullOrEmpty(account);
+        Throw.IfNullOrEmpty(account, nameof(account));
 
         if (!StrKey.IsValidEd25519PublicKey(account))
         {
@@ -46,7 +47,7 @@ public class PathsRequestBuilder : RequestBuilderExecutePageable<PathsRequestBui
     /// <exception cref="ArgumentException">Thrown when the account ID is invalid.</exception>
     public PathsRequestBuilder SourceAccount(string account)
     {
-        ArgumentException.ThrowIfNullOrEmpty(account);
+        Throw.IfNullOrEmpty(account, nameof(account));
 
         if (!StrKey.IsValidEd25519PublicKey(account))
         {

--- a/StellarDotnetSdk/Requests/RetryingHttpMessageHandler.cs
+++ b/StellarDotnetSdk/Requests/RetryingHttpMessageHandler.cs
@@ -99,6 +99,7 @@ public class RetryingHttpMessageHandler : DelegatingHandler
     /// <param name="request">The HTTP request message to send.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
     /// <returns>The HTTP response message.</returns>
+#if NET8_0_OR_GREATER
     protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         var context = ResilienceContextPool.Shared.Get(cancellationToken);
@@ -113,6 +114,7 @@ public class RetryingHttpMessageHandler : DelegatingHandler
             ResilienceContextPool.Shared.Return(context);
         }
     }
+#endif
 
     private static ResiliencePipeline<HttpResponseMessage> BuildPipeline(HttpResilienceOptions options)
     {

--- a/StellarDotnetSdk/Requests/TransactionsRequestBuilder.cs
+++ b/StellarDotnetSdk/Requests/TransactionsRequestBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using StellarDotnetSdk.Compatibility;
 using StellarDotnetSdk.Responses;
 
 namespace StellarDotnetSdk.Requests;
@@ -54,7 +55,7 @@ public class TransactionsRequestBuilder : RequestBuilderStreamable<TransactionsR
     /// <param name="account">Account for which to get transactions</param>
     public TransactionsRequestBuilder ForAccount(string account)
     {
-        ArgumentException.ThrowIfNullOrEmpty(account);
+        Throw.IfNullOrEmpty(account, nameof(account));
 
         if (!StrKey.IsValidEd25519PublicKey(account))
         {

--- a/StellarDotnetSdk/Responses/SorobanRpc/TransactionInfo.cs
+++ b/StellarDotnetSdk/Responses/SorobanRpc/TransactionInfo.cs
@@ -142,7 +142,7 @@ public class TransactionInfo
         {
             if (ResultValue is SCBytes bytes)
             {
-                return Convert.ToHexString(bytes.InnerValue);
+                return Util.BytesToHex(bytes.InnerValue);
             }
 
             return null;

--- a/StellarDotnetSdk/Sep/Sep0001/StellarToml.cs
+++ b/StellarDotnetSdk/Sep/Sep0001/StellarToml.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Nett;
+using StellarDotnetSdk.Compatibility;
 using StellarDotnetSdk.Requests;
 using StellarDotnetSdk.Sep.Sep0001.Exceptions;
 

--- a/StellarDotnetSdk/Sep/Sep0006/TransferServerService.cs
+++ b/StellarDotnetSdk/Sep/Sep0006/TransferServerService.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
+using StellarDotnetSdk.Compatibility;
 using StellarDotnetSdk.Converters;
 using StellarDotnetSdk.Requests;
 using StellarDotnetSdk.Responses;

--- a/StellarDotnetSdk/Sep/Sep0009/KycDateFormatting.cs
+++ b/StellarDotnetSdk/Sep/Sep0009/KycDateFormatting.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+#if !NETSTANDARD2_1
+using System.Globalization;
+using StellarDotnetSdk.Converters;
+#endif
+
+namespace StellarDotnetSdk.Sep.Sep0009;
+
+internal static class KycDateFormatting
+{
+#if NETSTANDARD2_1
+    internal static void AddIfPresent(Dictionary<string, string> result, string key, string? value)
+    {
+        if (value is not null)
+        {
+            result[key] = value;
+        }
+    }
+#else
+    internal static void AddIfPresent(Dictionary<string, string> result, string key, DateOnly? value)
+    {
+        if (value.HasValue)
+        {
+            result[key] = value.Value.ToString(DateOnlyJsonConverter.IsoDateFormat, CultureInfo.InvariantCulture);
+        }
+    }
+#endif
+}

--- a/StellarDotnetSdk/Sep/Sep0009/KycDateFormatting.cs
+++ b/StellarDotnetSdk/Sep/Sep0009/KycDateFormatting.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
-#if !NETSTANDARD2_1
 using System.Globalization;
+#if !NETSTANDARD2_1
 using StellarDotnetSdk.Converters;
 #endif
 
@@ -9,13 +9,24 @@ namespace StellarDotnetSdk.Sep.Sep0009;
 
 internal static class KycDateFormatting
 {
+    internal const string IsoDateFormat = "yyyy-MM-dd";
+
 #if NETSTANDARD2_1
     internal static void AddIfPresent(Dictionary<string, string> result, string key, string? value)
     {
-        if (value is not null)
+        if (value is null)
         {
-            result[key] = value;
+            return;
         }
+
+        if (!DateTime.TryParseExact(value, IsoDateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
+        {
+            throw new ArgumentException(
+                $"Date value '{value}' is not in the required ISO 8601 date-only format ({IsoDateFormat}).",
+                key);
+        }
+
+        result[key] = parsed.ToString(IsoDateFormat, CultureInfo.InvariantCulture);
     }
 #else
     internal static void AddIfPresent(Dictionary<string, string> result, string key, DateOnly? value)

--- a/StellarDotnetSdk/Sep/Sep0009/KycJsonOptions.cs
+++ b/StellarDotnetSdk/Sep/Sep0009/KycJsonOptions.cs
@@ -1,0 +1,41 @@
+using System.Text.Json;
+#if !NETSTANDARD2_1
+using StellarDotnetSdk.Converters;
+#endif
+
+namespace StellarDotnetSdk.Sep.Sep0009;
+
+/// <summary>
+///     JSON serializer options for SEP-0009 KYC field types.
+///     Date fields use ISO 8601 date-only format (yyyy-MM-dd) on frameworks that support date-only types.
+/// </summary>
+public static class KycJsonOptions
+{
+    /// <summary>
+    ///     Default JSON options for serializing and deserializing SEP-0009 KYC records.
+    /// </summary>
+    public static JsonSerializerOptions Default { get; } = CreateDefault();
+
+    private static JsonSerializerOptions CreateDefault()
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            RespectNullableAnnotations = true,
+#if !NETSTANDARD2_1
+            Converters =
+            {
+                new NullableDateOnlyJsonConverter(),
+                new DateOnlyJsonConverter(),
+            },
+#endif
+        };
+
+#if NET8_0_OR_GREATER
+        options.MakeReadOnly(true);
+#endif
+
+        return options;
+    }
+}

--- a/StellarDotnetSdk/Sep/Sep0009/KycJsonOptions.cs
+++ b/StellarDotnetSdk/Sep/Sep0009/KycJsonOptions.cs
@@ -42,9 +42,7 @@ public static class KycJsonOptions
 #endif
         };
 
-#if NET8_0_OR_GREATER
         options.MakeReadOnly(true);
-#endif
 
         return options;
     }

--- a/StellarDotnetSdk/Sep/Sep0009/KycJsonOptions.cs
+++ b/StellarDotnetSdk/Sep/Sep0009/KycJsonOptions.cs
@@ -9,10 +9,18 @@ namespace StellarDotnetSdk.Sep.Sep0009;
 ///     JSON serializer options for SEP-0009 KYC field types.
 ///     Date fields use ISO 8601 date-only format (yyyy-MM-dd) on frameworks that support date-only types.
 /// </summary>
+/// <remarks>
+///     These options use <see cref="JsonNamingPolicy.CamelCase" /> (emitting e.g. <c>birthDate</c>), so they are
+///     intended for internal/persistence serialization — NOT for the SEP-0009 wire format, which uses snake_case
+///     field keys (e.g. <c>birth_date</c>). SEP-0009 submission/parsing goes through the typed field models and
+///     their <c>*_FieldKey</c> constants, not these options. Deserializing a raw SEP-0009 server payload with
+///     <see cref="Default" /> would silently skip every snake_case field.
+/// </remarks>
 public static class KycJsonOptions
 {
     /// <summary>
-    ///     Default JSON options for serializing and deserializing SEP-0009 KYC records.
+    ///     Default JSON options for serializing and deserializing SEP-0009 KYC records for internal/persistence
+    ///     use. Uses camelCase property names, so it does not match the SEP-0009 snake_case wire format.
     /// </summary>
     public static JsonSerializerOptions Default { get; } = CreateDefault();
 
@@ -22,7 +30,9 @@ public static class KycJsonOptions
         {
             PropertyNameCaseInsensitive = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+#if NET10_0_OR_GREATER
             RespectNullableAnnotations = true,
+#endif
 #if !NETSTANDARD2_1
             Converters =
             {

--- a/StellarDotnetSdk/Sep/Sep0009/NaturalPersonKycFields.cs
+++ b/StellarDotnetSdk/Sep/Sep0009/NaturalPersonKycFields.cs
@@ -1,5 +1,9 @@
 using System;
 using System.Collections.Generic;
+#if !NETSTANDARD2_1
+using System.Text.Json.Serialization;
+using StellarDotnetSdk.Converters;
+#endif
 
 namespace StellarDotnetSdk.Sep.Sep0009;
 
@@ -272,7 +276,16 @@ public sealed record NaturalPersonKycFields
     /// <summary>
     ///     Date of birth, e.g. 1976-07-04
     /// </summary>
+    /// <remarks>
+    ///     Uses <c>DateOnly?</c> on net8.0/net10.0 and ISO date string (<c>yyyy-MM-dd</c>) on
+    ///     netstandard2.1.
+    /// </remarks>
+#if NETSTANDARD2_1
+    public string? BirthDate { get; init; }
+#else
+    [JsonConverter(typeof(NullableDateOnlyJsonConverter))]
     public DateOnly? BirthDate { get; init; }
+#endif
 
     /// <summary>
     ///     Place of birth (city, state, country; as on passport)
@@ -327,12 +340,30 @@ public sealed record NaturalPersonKycFields
     /// <summary>
     ///     ID issue date
     /// </summary>
+    /// <remarks>
+    ///     Uses <c>DateOnly?</c> on net8.0/net10.0 and ISO date string (<c>yyyy-MM-dd</c>) on
+    ///     netstandard2.1.
+    /// </remarks>
+#if NETSTANDARD2_1
+    public string? IdIssueDate { get; init; }
+#else
+    [JsonConverter(typeof(NullableDateOnlyJsonConverter))]
     public DateOnly? IdIssueDate { get; init; }
+#endif
 
     /// <summary>
     ///     ID expiration date
     /// </summary>
+    /// <remarks>
+    ///     Uses <c>DateOnly?</c> on net8.0/net10.0 and ISO date string (<c>yyyy-MM-dd</c>) on
+    ///     netstandard2.1.
+    /// </remarks>
+#if NETSTANDARD2_1
+    public string? IdExpirationDate { get; init; }
+#else
+    [JsonConverter(typeof(NullableDateOnlyJsonConverter))]
     public DateOnly? IdExpirationDate { get; init; }
+#endif
 
     /// <summary>
     ///     Passport or ID number
@@ -453,10 +484,7 @@ public sealed record NaturalPersonKycFields
         {
             result[EmailAddressFieldKey] = EmailAddress;
         }
-        if (BirthDate.HasValue)
-        {
-            result[BirthDateFieldKey] = BirthDate.Value.ToString("yyyy-MM-dd");
-        }
+        KycDateFormatting.AddIfPresent(result, BirthDateFieldKey, BirthDate);
         if (BirthPlace is not null)
         {
             result[BirthPlaceFieldKey] = BirthPlace;
@@ -497,14 +525,8 @@ public sealed record NaturalPersonKycFields
         {
             result[IdCountryCodeFieldKey] = IdCountryCode;
         }
-        if (IdIssueDate.HasValue)
-        {
-            result[IdIssueDateFieldKey] = IdIssueDate.Value.ToString("yyyy-MM-dd");
-        }
-        if (IdExpirationDate.HasValue)
-        {
-            result[IdExpirationDateFieldKey] = IdExpirationDate.Value.ToString("yyyy-MM-dd");
-        }
+        KycDateFormatting.AddIfPresent(result, IdIssueDateFieldKey, IdIssueDate);
+        KycDateFormatting.AddIfPresent(result, IdExpirationDateFieldKey, IdExpirationDate);
         if (IdNumber is not null)
         {
             result[IdNumberFieldKey] = IdNumber;

--- a/StellarDotnetSdk/Sep/Sep0009/OrganizationKycFields.cs
+++ b/StellarDotnetSdk/Sep/Sep0009/OrganizationKycFields.cs
@@ -1,5 +1,9 @@
 using System;
 using System.Collections.Generic;
+#if !NETSTANDARD2_1
+using System.Text.Json.Serialization;
+using StellarDotnetSdk.Converters;
+#endif
 
 namespace StellarDotnetSdk.Sep.Sep0009;
 
@@ -131,7 +135,16 @@ public sealed record OrganizationKycFields
     /// <summary>
     ///     Date the organization was registered
     /// </summary>
+    /// <remarks>
+    ///     Uses <c>DateOnly?</c> on net8.0/net10.0 and ISO date string (<c>yyyy-MM-dd</c>) on
+    ///     netstandard2.1.
+    /// </remarks>
+#if NETSTANDARD2_1
+    public string? RegistrationDate { get; init; }
+#else
+    [JsonConverter(typeof(NullableDateOnlyJsonConverter))]
     public DateOnly? RegistrationDate { get; init; }
+#endif
 
     /// <summary>
     ///     Organization registered address
@@ -228,10 +241,7 @@ public sealed record OrganizationKycFields
         {
             result[RegistrationNumberFieldKey] = RegistrationNumber;
         }
-        if (RegistrationDate.HasValue)
-        {
-            result[RegistrationDateFieldKey] = RegistrationDate.Value.ToString("yyyy-MM-dd");
-        }
+        KycDateFormatting.AddIfPresent(result, RegistrationDateFieldKey, RegistrationDate);
         if (RegisteredAddress is not null)
         {
             result[RegisteredAddressFieldKey] = RegisteredAddress;

--- a/StellarDotnetSdk/Sep/Sep0010/ClientWebAuth.cs
+++ b/StellarDotnetSdk/Sep/Sep0010/ClientWebAuth.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using StellarDotnetSdk.Accounts;
+using StellarDotnetSdk.Compatibility;
 using StellarDotnetSdk.Converters;
 using StellarDotnetSdk.Memos;
 using StellarDotnetSdk.Operations;
@@ -147,10 +148,10 @@ public class ClientWebAuth : IDisposable
         int? gracePeriod = null,
         HttpResilienceOptions? resilienceOptions = null)
     {
-        ArgumentException.ThrowIfNullOrEmpty(authEndpoint);
-        ArgumentNullException.ThrowIfNull(network);
-        ArgumentException.ThrowIfNullOrEmpty(serverSigningKey);
-        ArgumentException.ThrowIfNullOrEmpty(serverHomeDomain);
+        Throw.IfNullOrEmpty(authEndpoint, nameof(authEndpoint));
+        Throw.IfNull(network, nameof(network));
+        Throw.IfNullOrEmpty(serverSigningKey, nameof(serverSigningKey));
+        Throw.IfNullOrEmpty(serverHomeDomain, nameof(serverHomeDomain));
 
         _authEndpoint = authEndpoint;
         _network = network;
@@ -247,8 +248,8 @@ public class ClientWebAuth : IDisposable
         KeyPair? clientDomainAccountKeyPair = null,
         ClientDomainSigningDelegate? clientDomainSigningDelegate = null)
     {
-        ArgumentException.ThrowIfNullOrEmpty(clientAccountId);
-        ArgumentNullException.ThrowIfNull(signers);
+        Throw.IfNullOrEmpty(clientAccountId, nameof(clientAccountId));
+        Throw.IfNull(signers, nameof(signers));
 
         if (memo != null && clientAccountId.StartsWith("M", StringComparison.Ordinal))
         {
@@ -424,8 +425,8 @@ public class ClientWebAuth : IDisposable
         int? timeBoundsGracePeriod = null,
         ulong? memo = null)
     {
-        ArgumentException.ThrowIfNullOrEmpty(challengeTransaction);
-        ArgumentException.ThrowIfNullOrEmpty(userAccountId);
+        Throw.IfNullOrEmpty(challengeTransaction, nameof(challengeTransaction));
+        Throw.IfNullOrEmpty(userAccountId, nameof(userAccountId));
 
         // Convert to SDK Transaction early - single conversion point
         var transaction = Transaction.FromEnvelopeXdr(challengeTransaction);
@@ -587,8 +588,8 @@ public class ClientWebAuth : IDisposable
     /// <returns>Base64-encoded XDR transaction envelope with additional signatures</returns>
     public string SignTransaction(string challengeTransaction, ICollection<KeyPair> signers)
     {
-        ArgumentException.ThrowIfNullOrEmpty(challengeTransaction);
-        ArgumentNullException.ThrowIfNull(signers);
+        Throw.IfNullOrEmpty(challengeTransaction, nameof(challengeTransaction));
+        Throw.IfNull(signers, nameof(signers));
 
         // Convert to SDK Transaction for easy access
         var transaction = Transaction.FromEnvelopeXdr(challengeTransaction);
@@ -613,7 +614,7 @@ public class ClientWebAuth : IDisposable
     /// <returns>The JWT authentication token</returns>
     public async Task<string> SendSignedChallengeAsync(string base64EnvelopeXdr)
     {
-        ArgumentException.ThrowIfNullOrEmpty(base64EnvelopeXdr);
+        Throw.IfNullOrEmpty(base64EnvelopeXdr, nameof(base64EnvelopeXdr));
 
         var serverUri = new Uri(_authEndpoint);
 

--- a/StellarDotnetSdk/Sep/Sep0010/ServerWebAuth.cs
+++ b/StellarDotnetSdk/Sep/Sep0010/ServerWebAuth.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using StellarDotnetSdk.Accounts;
+using StellarDotnetSdk.Compatibility;
 using StellarDotnetSdk.Operations;
 using StellarDotnetSdk.Sep.Sep0010.Exceptions;
 using StellarDotnetSdk.Transactions;
@@ -110,13 +111,13 @@ public static class ServerWebAuth
         string? clientDomain = null,
         KeyPair? clientSigningKey = null)
     {
-        ArgumentNullException.ThrowIfNull(serverKeypair);
-        ArgumentNullException.ThrowIfNull(clientAccountId);
-        ArgumentException.ThrowIfNullOrEmpty(homeDomain);
-        ArgumentException.ThrowIfNullOrEmpty(webAuthDomain);
+        Throw.IfNull(serverKeypair, nameof(serverKeypair));
+        Throw.IfNull(clientAccountId, nameof(clientAccountId));
+        Throw.IfNullOrEmpty(homeDomain, nameof(homeDomain));
+        Throw.IfNullOrEmpty(webAuthDomain, nameof(webAuthDomain));
         if (!string.IsNullOrEmpty(clientDomain))
         {
-            ArgumentNullException.ThrowIfNull(clientSigningKey);
+            Throw.IfNull(clientSigningKey, nameof(clientSigningKey));
         }
 
         if (nonce is null)
@@ -278,7 +279,7 @@ public static class ServerWebAuth
         Network? network = null,
         DateTimeOffset? now = null)
     {
-        ArgumentNullException.ThrowIfNull(signerSummary);
+        Throw.IfNull(signerSummary, nameof(signerSummary));
         var signersFound = VerifyChallengeTransactionSigners(
             transaction,
             serverAccountId,
@@ -322,8 +323,8 @@ public static class ServerWebAuth
         Network? network = null,
         DateTimeOffset? now = null)
     {
-        ArgumentNullException.ThrowIfNull(signers);
-        ArgumentNullException.ThrowIfNull(transaction);
+        Throw.IfNull(signers, nameof(signers));
+        Throw.IfNull(transaction, nameof(transaction));
         if (signers.Count == 0)
         {
             throw new ArgumentException("Signers must be non-empty", nameof(signers));

--- a/StellarDotnetSdk/Sep/Sep0024/InteractiveService.cs
+++ b/StellarDotnetSdk/Sep/Sep0024/InteractiveService.cs
@@ -8,6 +8,7 @@ using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using StellarDotnetSdk.Compatibility;
 using StellarDotnetSdk.Converters;
 using StellarDotnetSdk.Requests;
 using StellarDotnetSdk.Sep.Sep0001;

--- a/StellarDotnetSdk/Sep/Sep0045/ClientWebAuthContract.cs
+++ b/StellarDotnetSdk/Sep/Sep0045/ClientWebAuthContract.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using StellarDotnetSdk.Accounts;
+using StellarDotnetSdk.Compatibility;
 using StellarDotnetSdk.Converters;
 using StellarDotnetSdk.Requests;
 using StellarDotnetSdk.Sep.Sep0001;
@@ -87,12 +88,12 @@ public class ClientWebAuthContract : IDisposable
         uint? signatureExpirationLedgers = null,
         HttpResilienceOptions? resilienceOptions = null)
     {
-        ArgumentException.ThrowIfNullOrEmpty(authEndpoint);
-        ArgumentException.ThrowIfNullOrEmpty(webAuthContractId);
-        ArgumentNullException.ThrowIfNull(network);
-        ArgumentException.ThrowIfNullOrEmpty(serverSigningKey);
-        ArgumentException.ThrowIfNullOrEmpty(serverHomeDomain);
-        ArgumentException.ThrowIfNullOrEmpty(sorobanRpcUrl);
+        Throw.IfNullOrEmpty(authEndpoint, nameof(authEndpoint));
+        Throw.IfNullOrEmpty(webAuthContractId, nameof(webAuthContractId));
+        Throw.IfNull(network, nameof(network));
+        Throw.IfNullOrEmpty(serverSigningKey, nameof(serverSigningKey));
+        Throw.IfNullOrEmpty(serverHomeDomain, nameof(serverHomeDomain));
+        Throw.IfNullOrEmpty(sorobanRpcUrl, nameof(sorobanRpcUrl));
 
         if (!Uri.TryCreate(authEndpoint, UriKind.Absolute, out var endpointUri))
         {
@@ -255,7 +256,7 @@ public class ClientWebAuthContract : IDisposable
         string? homeDomain = null,
         string? clientDomain = null)
     {
-        ArgumentException.ThrowIfNullOrEmpty(clientAccountId);
+        Throw.IfNullOrEmpty(clientAccountId, nameof(clientAccountId));
 
         var uri = new UriBuilder(_authEndpoint);
         var q = new List<string> { $"account={Uri.EscapeDataString(clientAccountId)}" };
@@ -374,8 +375,8 @@ public class ClientWebAuthContract : IDisposable
         string? clientDomain = null,
         string? homeDomain = null)
     {
-        ArgumentException.ThrowIfNullOrEmpty(authorizationEntriesXdr);
-        ArgumentException.ThrowIfNullOrEmpty(clientAccountId);
+        Throw.IfNullOrEmpty(authorizationEntriesXdr, nameof(authorizationEntriesXdr));
+        Throw.IfNullOrEmpty(clientAccountId, nameof(clientAccountId));
 
         var parsed = Sep45Challenge.ReadChallenge(
             authorizationEntriesXdr,
@@ -472,7 +473,7 @@ public class ClientWebAuthContract : IDisposable
         ClientDomainEntrySigningDelegate? clientDomainSigningDelegate = null,
         string? clientDomainAccountId = null)
     {
-        ArgumentException.ThrowIfNullOrEmpty(authorizationEntriesXdr);
+        Throw.IfNullOrEmpty(authorizationEntriesXdr, nameof(authorizationEntriesXdr));
         var entries = Sep45Challenge.DecodeAuthorizationEntries(authorizationEntriesXdr);
         return await SignDecodedEntriesAsync(
             entries, clientAccountId, signers, clientDomainAccountKeyPair,
@@ -489,8 +490,8 @@ public class ClientWebAuthContract : IDisposable
         ClientDomainEntrySigningDelegate? clientDomainSigningDelegate,
         string? clientDomainAccountId)
     {
-        ArgumentException.ThrowIfNullOrEmpty(clientAccountId);
-        ArgumentNullException.ThrowIfNull(signers);
+        Throw.IfNullOrEmpty(clientAccountId, nameof(clientAccountId));
+        Throw.IfNull(signers, nameof(signers));
 
         // The client-domain entry is signed either locally (clientDomainAccountKeyPair, which carries its
         // own account id) or remotely (clientDomainSigningDelegate). Remote signing additionally needs
@@ -610,7 +611,7 @@ public class ClientWebAuthContract : IDisposable
     public async Task<string> SendSignedChallengeAsync(
         string signedAuthorizationEntriesXdr, bool useFormUrlEncoded = true)
     {
-        ArgumentException.ThrowIfNullOrEmpty(signedAuthorizationEntriesXdr);
+        Throw.IfNullOrEmpty(signedAuthorizationEntriesXdr, nameof(signedAuthorizationEntriesXdr));
 
         using var req = new HttpRequestMessage(HttpMethod.Post, new Uri(_authEndpoint));
         if (useFormUrlEncoded)
@@ -758,8 +759,8 @@ public class ClientWebAuthContract : IDisposable
         KeyPair? clientDomainAccountKeyPair = null,
         ClientDomainEntrySigningDelegate? clientDomainSigningDelegate = null)
     {
-        ArgumentException.ThrowIfNullOrEmpty(clientAccountId);
-        ArgumentNullException.ThrowIfNull(signers);
+        Throw.IfNullOrEmpty(clientAccountId, nameof(clientAccountId));
+        Throw.IfNull(signers, nameof(signers));
 
         var resolvedClientDomainAccountId = clientDomainAccountKeyPair?.AccountId;
         if (resolvedClientDomainAccountId == null && clientDomainSigningDelegate != null)

--- a/StellarDotnetSdk/Sep/Sep0045/Sep45Challenge.cs
+++ b/StellarDotnetSdk/Sep/Sep0045/Sep45Challenge.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using StellarDotnetSdk.Accounts;
+using StellarDotnetSdk.Compatibility;
 using StellarDotnetSdk.Sep.Sep0045.Exceptions;
 using StellarDotnetSdk.Xdr;
 using Int64 = StellarDotnetSdk.Xdr.Int64;
@@ -56,8 +57,8 @@ public static class Sep45Challenge
         SorobanAuthorizationEntry entry,
         Network network)
     {
-        ArgumentNullException.ThrowIfNull(entry);
-        ArgumentNullException.ThrowIfNull(network);
+        Throw.IfNull(entry, nameof(entry));
+        Throw.IfNull(network, nameof(network));
 
         if (entry.Credentials.Discriminant.InnerValue !=
             SorobanCredentialsType.SorobanCredentialsTypeEnum.SOROBAN_CREDENTIALS_ADDRESS)
@@ -76,7 +77,7 @@ public static class Sep45Challenge
             },
             SorobanAuthorization = new HashIDPreimage.HashIDPreimageSorobanAuthorization
             {
-                NetworkID = new Hash(SHA256.HashData(Encoding.UTF8.GetBytes(network.NetworkPassphrase))),
+                NetworkID = new Hash(Util.Hash(Encoding.UTF8.GetBytes(network.NetworkPassphrase))),
                 Nonce = new Int64(addressCreds.Nonce.InnerValue),
                 SignatureExpirationLedger = new Uint32(addressCreds.SignatureExpirationLedger.InnerValue),
                 Invocation = entry.RootInvocation,
@@ -85,7 +86,7 @@ public static class Sep45Challenge
 
         var stream = new XdrDataOutputStream();
         HashIDPreimage.Encode(stream, preimage);
-        return SHA256.HashData(stream.ToArray());
+        return Util.Hash(stream.ToArray());
     }
 
     /// <summary>
@@ -101,9 +102,9 @@ public static class Sep45Challenge
         string serverAccountId,
         Network network)
     {
-        ArgumentNullException.ThrowIfNull(serverEntry);
-        ArgumentException.ThrowIfNullOrEmpty(serverAccountId);
-        ArgumentNullException.ThrowIfNull(network);
+        Throw.IfNull(serverEntry, nameof(serverEntry));
+        Throw.IfNullOrEmpty(serverAccountId, nameof(serverAccountId));
+        Throw.IfNull(network, nameof(network));
 
         if (serverEntry.Credentials.Discriminant.InnerValue !=
             SorobanCredentialsType.SorobanCredentialsTypeEnum.SOROBAN_CREDENTIALS_ADDRESS)
@@ -196,10 +197,10 @@ public static class Sep45Challenge
         {
             throw new InvalidArgumentsException("authorizationEntriesXdr must not be empty");
         }
-        ArgumentException.ThrowIfNullOrEmpty(serverAccountId);
-        ArgumentException.ThrowIfNullOrEmpty(webAuthContractId);
-        ArgumentNullException.ThrowIfNull(homeDomains);
-        ArgumentException.ThrowIfNullOrEmpty(webAuthDomain);
+        Throw.IfNullOrEmpty(serverAccountId, nameof(serverAccountId));
+        Throw.IfNullOrEmpty(webAuthContractId, nameof(webAuthContractId));
+        Throw.IfNull(homeDomains, nameof(homeDomains));
+        Throw.IfNullOrEmpty(webAuthDomain, nameof(webAuthDomain));
 
         var entries = DecodeEntriesFromBase64(authorizationEntriesXdr);
         if (entries.Length < 2)

--- a/StellarDotnetSdk/Soroban/SCVal.cs
+++ b/StellarDotnetSdk/Soroban/SCVal.cs
@@ -2043,7 +2043,7 @@ public class ContractExecutableWasm : ContractExecutable
     /// <returns>A <see cref="ContractExecutableWasm" /> instance.</returns>
     public static ContractExecutableWasm FromXdr(Xdr.ContractExecutable xdr)
     {
-        return new ContractExecutableWasm(Convert.ToHexString(xdr.WasmHash.InnerValue));
+        return new ContractExecutableWasm(Util.BytesToHex(xdr.WasmHash.InnerValue));
     }
 
     /// <summary>
@@ -2058,7 +2058,7 @@ public class ContractExecutableWasm : ContractExecutable
             {
                 InnerValue = ContractExecutableType.ContractExecutableTypeEnum.CONTRACT_EXECUTABLE_WASM,
             },
-            WasmHash = new Hash(Convert.FromHexString(WasmHash)),
+            WasmHash = new Hash(Util.HexToBytes(WasmHash)),
         };
     }
 }

--- a/StellarDotnetSdk/StellarDotnetSdk.csproj
+++ b/StellarDotnetSdk/StellarDotnetSdk.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net10.0;net8.0;netstandard2.1</TargetFrameworks>
         <Version>12.0.0</Version>
-        <ApplicationIcon/>
+        <ApplicationIcon />
         <OutputType>Library</OutputType>
-        <StartupObject/>
+        <StartupObject />
         <Description>The .NET Stellar SDK facilitates client integration with the Stellar Horizon API server and submission of Stellar transactions. It has two main uses: querying Horizon and building, signing, and submitting transactions to the Stellar network.</Description>
         <PackageId>stellar-dotnet-sdk</PackageId>
         <PackageLicense>sss</PackageLicense>
@@ -26,41 +26,51 @@
     <PropertyGroup>
         <PackageReadmeFile>nugetreadme.md</PackageReadmeFile>
     </PropertyGroup>
+
     <ItemGroup>
-        <PackageReference Include="dotnetstandard-bip32" Version="1.0.0"/>
-        <PackageReference Include="dotnetstandard-bip39" Version="1.0.2"/>
-        <PackageReference Include="LaunchDarkly.EventSource" Version="3.3.2"/>
-        <PackageReference Include="Nett" Version="0.10.0"/>
-        <PackageReference Include="NSec.Cryptography" Version="25.4.0"/>
-        <PackageReference Include="Polly" Version="8.4.0"/>
-        <PackageReference Include="System.Net.Http" Version="4.3.4"/>
-        <PackageReference Include="System.Text.Json" Version="10.0.6"/>
-        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"/>
+        <PackageReference Include="dotnetstandard-bip32" Version="1.0.0" />
+        <PackageReference Include="dotnetstandard-bip39" Version="1.0.2" />
+        <PackageReference Include="LaunchDarkly.EventSource" Version="3.3.2" />
+        <PackageReference Include="Nett" Version="0.10.0" />
+        <PackageReference Include="Polly" Version="8.4.0" />
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
+        <PackageReference Include="System.Text.Json" Version="10.0.6" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+        <PackageReference Include="Sodium.Core">
+          <Version>1.4.1</Version>
+        </PackageReference>
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">
+        <PackageReference Include="NSec.Cryptography" Version="25.4.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="..\LICENSE.txt" Pack="true" PackagePath=""/>
+        <None Include="..\LICENSE.txt" Pack="true" PackagePath="" />
     </ItemGroup>
     <ItemGroup>
-        <None Include="..\nugetreadme.md" Pack="true" PackagePath=""/>
+        <None Include="..\nugetreadme.md" Pack="true" PackagePath="" />
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\StellarDotnetSdk.Xdr\StellarDotnetSdk.Xdr.csproj"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <Folder Include="converters\"/>
-        <Folder Include="federation\"/>
-        <Folder Include="Properties\"/>
+        <ProjectReference Include="..\StellarDotnetSdk.Xdr\StellarDotnetSdk.Xdr.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <Compile Remove="Operations\AllowTrustOperation.cs"/>
-        <Compile Remove="Operations\InflationOperation.cs"/>
-        <Compile Remove="Operations\ManageOfferOperation.cs"/>
+        <Folder Include="converters\" />
+        <Folder Include="federation\" />
+        <Folder Include="Properties\" />
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="StellarDotnetSdk.Tests"/>
+        <Compile Remove="Operations\AllowTrustOperation.cs" />
+        <Compile Remove="Operations\InflationOperation.cs" />
+        <Compile Remove="Operations\ManageOfferOperation.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="StellarDotnetSdk.Tests" />
+        <InternalsVisibleTo Include="StellarDotnetSdk.NetStandard21.Tests" />
     </ItemGroup>
 </Project>

--- a/StellarDotnetSdk/StellarDotnetSdk.csproj
+++ b/StellarDotnetSdk/StellarDotnetSdk.csproj
@@ -39,8 +39,11 @@
         <PackageReference Include="Sodium.Core" Version="1.4.1" />
         <PackageReference Include="System.Text.Json" Version="8.0.5" />
     </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
         <PackageReference Include="NSec.Cryptography" Version="25.4.0" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="NSec.Cryptography" Version="26.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/StellarDotnetSdk/StellarDotnetSdk.csproj
+++ b/StellarDotnetSdk/StellarDotnetSdk.csproj
@@ -33,15 +33,11 @@
         <PackageReference Include="LaunchDarkly.EventSource" Version="3.3.2" />
         <PackageReference Include="Nett" Version="0.10.0" />
         <PackageReference Include="Polly" Version="8.4.0" />
-        <PackageReference Include="System.Net.Http" Version="4.3.4" />
-        <PackageReference Include="System.Text.Json" Version="10.0.6" />
-        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-        <PackageReference Include="Sodium.Core">
-          <Version>1.4.1</Version>
-        </PackageReference>
+        <PackageReference Include="Sodium.Core" Version="1.4.1" />
+        <PackageReference Include="System.Text.Json" Version="8.0.5" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">
         <PackageReference Include="NSec.Cryptography" Version="25.4.0" />

--- a/StellarDotnetSdk/Util.cs
+++ b/StellarDotnetSdk/Util.cs
@@ -55,9 +55,12 @@ public static class Util
     /// <returns>Sha-256 Hash</returns>
     public static byte[] Hash(byte[] data)
     {
-        var mySha256 = SHA256.Create();
-        var hash = mySha256.ComputeHash(data);
-        return hash;
+#if NET8_0_OR_GREATER
+        return SHA256.HashData(data);
+#else
+        using var sha256 = SHA256.Create();
+        return sha256.ComputeHash(data);
+#endif
     }
 
     /// <summary>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.x",
+    "version": "10.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/nugetreadme.md
+++ b/nugetreadme.md
@@ -1,3 +1,13 @@
 The .NET Stellar SDK facilitates client integration with the Stellar Horizon API server and submission of Stellar
 transactions. It has two main uses: querying Horizon and building, signing, and submitting transactions to the Stellar
 network.
+
+## Supported target frameworks
+
+| TFM | Platforms |
+|-----|-----------|
+| `net10.0` | .NET 10 |
+| `net8.0` | .NET 8 |
+| `netstandard2.1` | Unity, Tizen, portable libraries |
+
+On `netstandard2.1`, SEP-0009 date properties are `string?` (ISO `yyyy-MM-dd`); on `net8.0` / `net10.0` they are `DateOnly?`.

--- a/stellar-dotnet-sdk.sln
+++ b/stellar-dotnet-sdk.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StellarDotnetSdk.Tests", "S
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StellarDotnetSdk.IntegrationTests", "StellarDotnetSdk.IntegrationTests\StellarDotnetSdk.IntegrationTests.csproj", "{2B5775A5-0A56-46CF-8A1A-EA1FB1FE7B95}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StellarDotnetSdk.NetStandard21.Tests", "StellarDotnetSdk.NetStandard21.Tests\StellarDotnetSdk.NetStandard21.Tests.csproj", "{F185A886-457B-4A1B-99A0-D26CE102BFAA}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StellarDotnetSdk.Console", "StellarDotnetSdk.Console\StellarDotnetSdk.Console.csproj", "{7BA6DFB8-5736-47EC-8995-E652D221E077}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StellarDotnetSdk.Xdr", "StellarDotnetSdk.Xdr\StellarDotnetSdk.Xdr.csproj", "{DB19EF41-BF22-41D0-B856-858C6FC17068}"
@@ -82,6 +84,10 @@ Global
 		{2B5775A5-0A56-46CF-8A1A-EA1FB1FE7B95}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2B5775A5-0A56-46CF-8A1A-EA1FB1FE7B95}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2B5775A5-0A56-46CF-8A1A-EA1FB1FE7B95}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F185A886-457B-4A1B-99A0-D26CE102BFAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F185A886-457B-4A1B-99A0-D26CE102BFAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F185A886-457B-4A1B-99A0-D26CE102BFAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F185A886-457B-4A1B-99A0-D26CE102BFAA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
[GitHub Issue](https://github.com/Beans-BV/dotnet-stellar-sdk/issues/162)

## Solution

Adds multi-targeting (`net10.0` / `net8.0` / `netstandard2.1`) to both `stellar-dotnet-sdk` and `stellar-dotnet-sdk-xdr`, enabling the SDK to run on .NET 8/10 backends and portable runtimes such as Unity 2022.3+, Unity 6, and Tizen 5.5+.

Multi-targeting & Packaging:

* Retarget `StellarDotnetSdk` and `StellarDotnetSdk.Xdr` to:

  * `net10.0`
  * `net8.0`
  * `netstandard2.1`
* Enable NuGet package validation using `CompatibilitySuppressions.xml` for intentional API differences between target frameworks.
* Update CI (`pack_and_test.yml`) to build, pack, and test all three target frameworks.
* Document platform support in `README.md` and `nugetreadme.md`.

Crypto Abstraction:

* Introduce an internal `Ed25519` facade in `Crypto/Ed25519.cs`:

  * `net8.0` / `net10.0` → `NSec.Cryptography`
  * `netstandard2.1` → `Sodium.Core` (`PublicKeyAuth.GenerateKeyPair` + `SignDetached`)
* Refactor `KeyPair` to delegate signing, verification, and public key derivation to `Ed25519`.
* Add `Ed25519CrossProviderTest` (`net10.0`) to verify that `NSec` and `Sodium` produce byte-identical keys and signatures using:

  * RFC 8032 test vectors
  * Existing `KeyPairTest` vectors
  * Cross-provider verification
  * 1,000 randomized iterations

Compatibility Layer (`netstandard2.1`):

* Add compatibility helpers:

  * `Throw`
  * `HttpContentExtensions`
  * Compiler polyfills
* Add XDR compatibility shims:

  * `NetstandardCompat`
  * `Throw`
* Update XDR generator templates to use compatibility shims.
* Add conditional compilation for APIs unavailable on `netstandard2.1`, including:

  * `HttpClient.Send`
  * `JsonSerializerOptions.MakeReadOnly`
  * Other modern BCL APIs

SEP-0009 Date Handling:

Target-framework-specific handling is used while preserving the same JSON wire format across all targets:

* `net8.0` / `net10.0`

  * `DateOnly?`
  * `DateOnlyJsonConverter`
  * `NullableDateOnlyJsonConverter`

* `netstandard2.1`

  * `string?` (`yyyy-MM-dd`)
  * `KycDateFormatting`
  * `KycJsonOptions`

Additional compatibility details are documented in `SEP-0009_COMPATIBILITY_MATRIX.md`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
