### PR TITLE
feat: `getLatestLedger` response fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- `GetLatestLedgerResponse` now exposes the remaining `getLatestLedger` fields served by Stellar RPC:
+  `CloseTime` (unix timestamp as a string, matching the wire format), `HeaderXdr`, and `MetadataXdr`.
+  All three are nullable so responses from older RPC servers that omit them still deserialize
+  ([#198](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/198), completes
+  [#155](https://github.com/Beans-BV/dotnet-stellar-sdk/issues/155) and
+  [#159](https://github.com/Beans-BV/dotnet-stellar-sdk/issues/159)).
 - **Protocol 27 (CAP-71) Soroban authorization** ([#187](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/187), implements [#186](https://github.com/Beans-BV/dotnet-stellar-sdk/issues/186)):
   - `SorobanAddressCredentialsV2` — CAP-0071-02 address-bound credentials (`SOROBAN_CREDENTIALS_ADDRESS_V2`),
     whose signature is computed over the `ENVELOPE_TYPE_SOROBAN_AUTHORIZATION_WITH_ADDRESS` preimage,

--- a/Examples/Soroban/Examples/GetLatestLedgerExample.cs
+++ b/Examples/Soroban/Examples/GetLatestLedgerExample.cs
@@ -16,5 +16,9 @@ internal static class GetLatestLedgerExample
 
         Console.WriteLine($"Server protocol version: {response.ProtocolVersion}");
         Console.WriteLine($"Server latest ledger: {response.Sequence}");
+        Console.WriteLine($"Latest ledger hash: {response.Id}");
+        Console.WriteLine($"Latest ledger close time (unix): {response.CloseTime}");
+        Console.WriteLine($"Latest ledger header XDR: {response.HeaderXdr}");
+        Console.WriteLine($"Latest ledger metadata XDR length: {response.MetadataXdr?.Length}");
     }
 }

--- a/StellarDotnetSdk.Tests/SorobanServerTest.cs
+++ b/StellarDotnetSdk.Tests/SorobanServerTest.cs
@@ -124,7 +124,10 @@ public class StellarRpcServerTest
               "result": {
                 "id": "6bdb3e5cd5dcbf53df4b67dd56f892d0134c5abfb659234a83778af0b85620fe",
                 "protocolVersion": 21,
-                "sequence": 453871
+                "sequence": 453871,
+                "closeTime": "1750898400",
+                "headerXdr": "AAAAFgAAAADSFCi7HpJnjZuJ4nH4YkbFDcM/hQ/JcCJ1PxJnUp9pyg==",
+                "metadataXdr": "AAAAAgAAAADSFCi7HpJnjZuJ4nH4YkbFDcM/hQ/JcCJ1PxJnUp9pyg=="
               }
             }
             """;
@@ -138,6 +141,42 @@ public class StellarRpcServerTest
         Assert.AreEqual(21, response.ProtocolVersion);
         Assert.AreEqual(453871, response.Sequence);
         Assert.AreEqual("6bdb3e5cd5dcbf53df4b67dd56f892d0134c5abfb659234a83778af0b85620fe", response.Id);
+        Assert.AreEqual("1750898400", response.CloseTime);
+        Assert.AreEqual("AAAAFgAAAADSFCi7HpJnjZuJ4nH4YkbFDcM/hQ/JcCJ1PxJnUp9pyg==", response.HeaderXdr);
+        Assert.AreEqual("AAAAAgAAAADSFCi7HpJnjZuJ4nH4YkbFDcM/hQ/JcCJ1PxJnUp9pyg==", response.MetadataXdr);
+    }
+
+    /// <summary>
+    ///     Verifies that StellarRpcServer.GetLatestLedger tolerates responses from RPC servers that omit the
+    ///     ledger close time, header, and metadata fields.
+    /// </summary>
+    [TestMethod]
+    public async Task GetLatestLedger_WithoutOptionalFields_ReturnsNullForMissingFields()
+    {
+        // Arrange
+        const string getLatestLedgerResponseJson =
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": "8675309",
+              "result": {
+                "id": "6bdb3e5cd5dcbf53df4b67dd56f892d0134c5abfb659234a83778af0b85620fe",
+                "protocolVersion": 21,
+                "sequence": 453871
+              }
+            }
+            """;
+
+        using var sorobanServer = Utils.CreateTestStellarRpcServerWithContent(getLatestLedgerResponseJson);
+
+        // Act
+        var response = await sorobanServer.GetLatestLedger();
+
+        // Assert
+        Assert.AreEqual(453871, response.Sequence);
+        Assert.IsNull(response.CloseTime);
+        Assert.IsNull(response.HeaderXdr);
+        Assert.IsNull(response.MetadataXdr);
     }
 
     /// <summary>

--- a/StellarDotnetSdk/Compatibility/horizon_matrix.md
+++ b/StellarDotnetSdk/Compatibility/horizon_matrix.md
@@ -1,16 +1,19 @@
 # Horizon API vs Stellar .NET SDK Compatibility Matrix
 
-**Horizon Version:** v27.0.0 (released 2026-06-11)  
-**Horizon Source:** [v27.0.0](https://github.com/stellar/stellar-horizon/releases/tag/v27.0.0)  
+**Horizon Version:** v28.0.1 (released 2026-08-27)  
+**Horizon Source:** [v28.0.1](https://github.com/stellar/stellar-horizon/releases/tag/v28.0.1)  
 **SDK:** `StellarDotnetSdk`  
 **SDK Version:** 14.0.0  
-**Updated:** 2026-07-02
+**Updated:** 2026-08-28
 
 > **Version history:** Horizon v26.0.0 (Protocol 26) added no new endpoints — its API-visible changes were CAP-77
 > result codes (SDK support in [#177](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/177)) and CAP-73 effects
 > reusing the existing `contract_credited`/`contract_debited` types (SDK support in
 > [#179](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/179)). Horizon v27.0.0 (Protocol 27) added ingestion
-> support only, with no endpoint or response-schema changes.
+> support only, with no endpoint or response-schema changes. Horizon v27.0.1, v28.0.0 (Protocol 28, CAP-0085
+> ingestion), and v28.0.1 likewise added no endpoints or response-schema changes. Protocol 28 XDR is not yet
+> regenerated in the SDK ([#207](https://github.com/Beans-BV/dotnet-stellar-sdk/issues/207)), so XDR fields on
+> Horizon responses that carry CAP-0085 types cannot be decoded until that lands.
 
 **Public API Endpoints (in matrix):** 50
 

--- a/StellarDotnetSdk/Compatibility/horizon_matrix.md
+++ b/StellarDotnetSdk/Compatibility/horizon_matrix.md
@@ -1,10 +1,16 @@
 # Horizon API vs Stellar .NET SDK Compatibility Matrix
 
-**Horizon Version:** v25.0.0 (released 2025-12-11)  
-**Horizon Source:** [v25.0.0](https://github.com/stellar/stellar-horizon/releases/tag/v25.0.0)  
+**Horizon Version:** v27.0.0 (released 2026-06-11)  
+**Horizon Source:** [v27.0.0](https://github.com/stellar/stellar-horizon/releases/tag/v27.0.0)  
 **SDK:** `StellarDotnetSdk`  
 **SDK Version:** 14.0.0  
-**Updated:** 2026-03-27
+**Updated:** 2026-07-02
+
+> **Version history:** Horizon v26.0.0 (Protocol 26) added no new endpoints — its API-visible changes were CAP-77
+> result codes (SDK support in [#177](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/177)) and CAP-73 effects
+> reusing the existing `contract_credited`/`contract_debited` types (SDK support in
+> [#179](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/179)). Horizon v27.0.0 (Protocol 27) added ingestion
+> support only, with no endpoint or response-schema changes.
 
 **Public API Endpoints (in matrix):** 50
 

--- a/StellarDotnetSdk/Compatibility/rpc_matrix.md
+++ b/StellarDotnetSdk/Compatibility/rpc_matrix.md
@@ -1,16 +1,25 @@
 # Stellar RPC vs .NET SDK Compatibility Matrix
 
-**RPC Version:** v26.0.1 (released 2026-06-10)
-**RPC Source:** [https://github.com/stellar/stellar-rpc/releases/tag/v26.0.1](https://github.com/stellar/stellar-rpc/releases/tag/v26.0.1)
+**RPC Version:** v28.0.1 (released 2026-08-27)
+**RPC Source:** [https://github.com/stellar/stellar-rpc/releases/tag/v28.0.1](https://github.com/stellar/stellar-rpc/releases/tag/v28.0.1)
 **SDK Version:** 12.0.0
-**Updated:** 2026-07-02
+**Updated:** 2026-08-28
+
+> **Version history:** RPC v26.0.1 completed the `getLatestLedger` response (`closeTime`, `headerXdr`, `metadataXdr`;
+> SDK support in [#198](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/198)). RPC v27.1.0 added two optional
+> `getHealth` response fields (`latestLedgerCloseTime`, `oldestLedgerCloseTime`) and an optional `simulateTransaction`
+> request flag (`useUpgradedAuth`, tracked in [#206](https://github.com/Beans-BV/dotnet-stellar-sdk/issues/206)).
+> RPC v27.0.0 and v28.0.0 changed no method signatures; they updated the XDR to Protocol 27 and Protocol 28
+> (CAP-0083, CAP-0085). Protocol 28 XDR is not yet regenerated in the SDK
+> ([#207](https://github.com/Beans-BV/dotnet-stellar-sdk/issues/207)), so `SCV_EXECUTABLE_TAG` values and
+> `CONTRACT_EXECUTABLE_EXTERNAL_REF` executables in RPC responses cannot be decoded until that lands.
 
 ## Overall Coverage
 
-**Coverage:** 100%
+**Coverage:** 83%
 
-- ✅ **Fully Supported:** 12/12
-- ⚠️ **Partially Supported:** 0/12
+- ✅ **Fully Supported:** 10/12
+- ⚠️ **Partially Supported:** 2/12
 - ❌ **Not Supported:** 0/12
 
 ## Method Comparison
@@ -19,7 +28,7 @@
 |------------|--------|----------------|-----------------|-----------------|-------|
 | `getEvents` | ✅ Fully Supported | `getEvents` | 1/1 | 6/6 | All parameters and response fields implemented |
 | `getFeeStats` | ✅ Fully Supported | `getFeeStats` | N/A | 3/3 | All parameters and response fields implemented |
-| `getHealth` | ✅ Fully Supported | `getHealth` | N/A | 4/4 | All parameters and response fields implemented |
+| `getHealth` | ⚠️ Partially Supported | `getHealth` | N/A | 4/6 | Missing `latestLedgerCloseTime` and `oldestLedgerCloseTime` (added in RPC v27.1.0) |
 | `getLatestLedger` | ✅ Fully Supported | `getLatestLedger` | N/A | 6/6 | All parameters and response fields implemented |
 | `getLedgerEntries` | ✅ Fully Supported | `getLedgerEntries` | 1/1 | 2/2 | All parameters and response fields implemented |
 | `getLedgers` | ✅ Fully Supported | `getLedgers` | 1/1 | 6/6 | All parameters and response fields implemented |
@@ -28,7 +37,7 @@
 | `getTransactions` | ✅ Fully Supported | `getTransactions` | 1/1 | 6/6 | All parameters and response fields implemented |
 | `getVersionInfo` | ✅ Fully Supported | `getVersionInfo` | N/A | 5/5 | All parameters and response fields implemented |
 | `sendTransaction` | ✅ Fully Supported | `sendTransaction` | 1/1 | N/A | All parameters and response fields implemented |
-| `simulateTransaction` | ✅ Fully Supported | `simulateTransaction` | 1/1 | N/A | All parameters and response fields implemented |
+| `simulateTransaction` | ⚠️ Partially Supported | `simulateTransaction` | 1/1 | N/A | Optional `useUpgradedAuth` request flag (RPC v27.1.0) not exposed, see [#206](https://github.com/Beans-BV/dotnet-stellar-sdk/issues/206) |
 
 ## Response Field Coverage
 
@@ -38,7 +47,7 @@ Detailed breakdown of response field support per method.
 |------------|------------|------------|----------------|
 | `getEvents` | 6 | 6 | - |
 | `getFeeStats` | 3 | 3 | - |
-| `getHealth` | 4 | 4 | - |
+| `getHealth` | 6 | 4 | `latestLedgerCloseTime`, `oldestLedgerCloseTime` |
 | `getLatestLedger` | 6 | 6 | - |
 | `getLedgerEntries` | 2 | 2 | - |
 | `getLedgers` | 6 | 6 | - |

--- a/StellarDotnetSdk/Compatibility/rpc_matrix.md
+++ b/StellarDotnetSdk/Compatibility/rpc_matrix.md
@@ -1,9 +1,9 @@
 # Stellar RPC vs .NET SDK Compatibility Matrix
 
-**RPC Version:** v25.0.0 (released 2025-12-12)
-**RPC Source:** [https://github.com/stellar/stellar-rpc/releases/tag/v25.0.0](https://github.com/stellar/stellar-rpc/releases/tag/v25.0.0)
+**RPC Version:** v26.0.1 (released 2026-06-10)
+**RPC Source:** [https://github.com/stellar/stellar-rpc/releases/tag/v26.0.1](https://github.com/stellar/stellar-rpc/releases/tag/v26.0.1)
 **SDK Version:** 12.0.0
-**Updated:** 2026-03-27
+**Updated:** 2026-07-02
 
 ## Overall Coverage
 
@@ -20,7 +20,7 @@
 | `getEvents` | ✅ Fully Supported | `getEvents` | 1/1 | 6/6 | All parameters and response fields implemented |
 | `getFeeStats` | ✅ Fully Supported | `getFeeStats` | N/A | 3/3 | All parameters and response fields implemented |
 | `getHealth` | ✅ Fully Supported | `getHealth` | N/A | 4/4 | All parameters and response fields implemented |
-| `getLatestLedger` | ✅ Fully Supported | `getLatestLedger` | N/A | 3/3 | All parameters and response fields implemented |
+| `getLatestLedger` | ✅ Fully Supported | `getLatestLedger` | N/A | 6/6 | All parameters and response fields implemented |
 | `getLedgerEntries` | ✅ Fully Supported | `getLedgerEntries` | 1/1 | 2/2 | All parameters and response fields implemented |
 | `getLedgers` | ✅ Fully Supported | `getLedgers` | 1/1 | 6/6 | All parameters and response fields implemented |
 | `getNetwork` | ✅ Fully Supported | `getNetwork` | N/A | 3/3 | All parameters and response fields implemented |
@@ -39,7 +39,7 @@ Detailed breakdown of response field support per method.
 | `getEvents` | 6 | 6 | - |
 | `getFeeStats` | 3 | 3 | - |
 | `getHealth` | 4 | 4 | - |
-| `getLatestLedger` | 3 | 3 | - |
+| `getLatestLedger` | 6 | 6 | - |
 | `getLedgerEntries` | 2 | 2 | - |
 | `getLedgers` | 6 | 6 | - |
 | `getNetwork` | 3 | 3 | - |

--- a/StellarDotnetSdk/Responses/SorobanRpc/GetLatestLedgerResponse.cs
+++ b/StellarDotnetSdk/Responses/SorobanRpc/GetLatestLedgerResponse.cs
@@ -2,7 +2,8 @@
 
 /// <summary>
 ///     Represents the response from the Soroban RPC <c>getLatestLedger</c> method.
-///     Contains the hash, sequence number, and protocol version of the most recent ledger.
+///     Contains the hash, sequence number, protocol version, close time, and encoded header and metadata of the most
+///     recent ledger.
 /// </summary>
 public class GetLatestLedgerResponse
 {
@@ -21,4 +22,19 @@ public class GetLatestLedgerResponse
     ///     The sequence number of the latest ledger known to Stellar RPC at the time it handled the request.
     /// </summary>
     public int Sequence { get; init; }
+
+    /// <summary>
+    ///     The unix timestamp of the close time of the latest ledger, encoded as a string.
+    /// </summary>
+    public string? CloseTime { get; init; }
+
+    /// <summary>
+    ///     The base-64 encoded XDR of the latest ledger's header.
+    /// </summary>
+    public string? HeaderXdr { get; init; }
+
+    /// <summary>
+    ///     The base-64 encoded XDR of the latest ledger's close metadata.
+    /// </summary>
+    public string? MetadataXdr { get; init; }
 }

--- a/docs/tutorials/examples/soroban/soroban-server-info.md
+++ b/docs/tutorials/examples/soroban/soroban-server-info.md
@@ -64,12 +64,22 @@ private static async Task GetLatestLedger()
     var response = await server.GetLatestLedger();
     Console.WriteLine($"Server protocol version: {response.ProtocolVersion}");
     Console.WriteLine($"Server latest ledger: {response.Sequence}");
+    Console.WriteLine($"Latest ledger hash: {response.Id}");
+    Console.WriteLine($"Latest ledger close time (unix): {response.CloseTime}");
+    Console.WriteLine($"Latest ledger header XDR: {response.HeaderXdr}");
+    Console.WriteLine($"Latest ledger metadata XDR length: {response.MetadataXdr?.Length}");
 }
 ```
 
 This provides:
 - The current protocol version running on the server
 - The sequence number of the latest ledger processed by the server
+- The hash of the latest ledger (`Id`)
+- The close time of the latest ledger as a unix timestamp string (`CloseTime`)
+- The base64-encoded XDR of the ledger header (`HeaderXdr`) and close metadata (`MetadataXdr`)
+
+`CloseTime`, `HeaderXdr`, and `MetadataXdr` are nullable: they are `null` when the RPC server is older than
+v26 and omits them.
 
 ## Retrieving Account Information
 


### PR DESCRIPTION
Completes the remaining RPC item from #155 (the `getLatestLedger` response fields were still missing when that issue was closed with the 15.1.0 release) and the compatibility-matrix scope of #159.

- Add `closeTime`, `headerXdr`, and `metadataXdr` to `GetLatestLedgerResponse` (6/6 response fields), with tests for both populated and omitted fields — the fields are nullable so responses from older RPC servers that omit them still deserialize under `RespectNullableAnnotations`.
- Pin `rpc_matrix.md` to RPC [v26.0.1](https://github.com/stellar/stellar-rpc/releases/tag/v26.0.1) — no new methods since v25 (still 12/12); `getLatestLedger` response coverage goes 3/3 → 6/6.
- Pin `horizon_matrix.md` to Horizon [v27.0.0](https://github.com/stellar/stellar-horizon/releases/tag/v27.0.0) — v26/v27 added no new endpoints or response schemas; the API-visible changes (CAP-77 result codes, CAP-73 effects) were already covered by #177/#179. Endpoint coverage stays 100% (50/50). A version-history note in the matrix documents this.

> **Note on the field name:** #155 (and upstream [stellar-rpc#554](https://github.com/stellar/stellar-rpc/pull/554)) referred to the close-time field as `ledgerCloseTime`, but the wire name actually served by stellar-rpc is `closeTime` — verified against the v26.0.1 handler source and the `go-stellar-sdk` protocol struct (`json:"closeTime,string"`). The SDK property follows the real schema. It is kept as a string (stringified int64 unix timestamp) to match the wire format, consistent with `LedgerInfo.LedgerCloseTime` from `getLedgers`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.