### PR TITLE
Post-review hardening: fixes for the #195 review findings

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -24,7 +24,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          # 10.0.x satisfies global.json (the runner image happened to preinstall it, which is why
+          # the old 8.0.x-only pin worked by accident); 8.0.x supplies the runtime the net8.0
+          # integration-test project executes on.
+          dotnet-version: |
+            8.0.x
+            10.0.x
       - name: Run integration tests
         env:
           INTEGRATION_HORIZON_URL:       ${{ vars.INTEGRATION_HORIZON_URL       || 'https://horizon-testnet.stellar.org' }}

--- a/.github/workflows/xdr_generator_tests.yml
+++ b/.github/workflows/xdr_generator_tests.yml
@@ -1,0 +1,29 @@
+name: XDR Generator Tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+permissions:
+  contents: read
+jobs:
+  xdr_generator_tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: StellarDotnetSdk.Xdr/xdr-generator
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+          working-directory: StellarDotnetSdk.Xdr/xdr-generator
+      - name: Run generator snapshot tests
+        run: bundle exec ruby -Itest test/generator_snapshot_test.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,9 +62,21 @@ All notable changes to this project are documented here. The format is based on
   environmental failures — e.g. a missing native libsodium — now propagate instead of being misreported
   as an invalid signature ([#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195)).
 - On `netstandard2.1`, the default HTTP handler is `HttpClientHandler` (`SocketsHttpHandler` on
-  `net8.0`/`net10.0`), and `RetryingHttpMessageHandler` overrides the synchronous `HttpClient.Send`
-  path only on `net8.0`/`net10.0` — use `SendAsync` on `netstandard2.1`
+  `net8.0`/`net10.0`). `RetryingHttpMessageHandler` runs the synchronous `HttpClient.Send` path
+  through the full resilience pipeline on `net8.0`/`net10.0`; on the `netstandard2.1` assembly
+  (which `net5`–`net7` apps also resolve) it derives from `HttpMessageHandler` instead of
+  `DelegatingHandler`, so synchronous `Send` on a .NET 5+ host throws `NotSupportedException`
+  instead of silently bypassing retries/circuit-breaker — use `SendAsync`. Consequently the handler
+  does not expose `DelegatingHandler.InnerHandler` on `netstandard2.1`
   ([#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195)).
+- `KeyPair.Sign` expands/imports the Ed25519 signing key once per `KeyPair` instance (lazily,
+  thread-safe) and reuses it for subsequent signatures, instead of re-deriving it on every call —
+  repeated signing with the same instance is ~3–4× faster on both crypto backends
+  ([#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195) follow-up).
+- **Breaking (behavioral):** `KeyPair` constructors and byte-array factories (`FromPublicKey`,
+  `FromSecretSeed(byte[])`) now throw `ArgumentException` for wrong-length key material and
+  `ArgumentNullException` for null, uniformly on all target frameworks and always at construction
+  time. Previous releases surfaced NSec's `FormatException` instead.
 
 ### Removed
 
@@ -77,3 +89,39 @@ All notable changes to this project are documented here. The format is based on
 - `Util.Hash` no longer leaks a `SHA256` instance on every call: it uses the static
   `SHA256.HashData` on `net8.0`/`net10.0` and a properly disposed instance on `netstandard2.1`
   ([#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195)).
+- `KeyPair` construction-time validation lost in
+  [#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195) is restored: the
+  `KeyPair(byte[], byte[]?, byte[]?)` constructor rejects public keys, private keys, and seeds that
+  are not exactly 32 bytes (e.g. `FromPublicKey(new byte[16])` no longer constructs a keypair with a
+  malformed account ID), and the `privateKey`/`seed` arguments are tracked separately again — a
+  seed-only `KeyPair` reports `CanSign() == false` and a private-key-only `KeyPair` no longer
+  exposes the private key through `SecretSeed`/`SeedBytes`.
+- SEP-0009 KYC date fields (`BirthDate`, `IdIssueDate`, `IdExpirationDate`, `RegistrationDate`) are
+  now validated during JSON (de)serialization on `netstandard2.1` too: the new
+  `IsoDateStringJsonConverter` rejects anything but `yyyy-MM-dd` with a `JsonException` on both read
+  and write, matching the `DateOnly`-based behavior on `net8.0`/`net10.0`. Previously the
+  `netstandard2.1` build silently accepted and re-emitted malformed date strings through
+  `KycJsonOptions` ([#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195) follow-up).
+- The XDR generator's blessed test snapshots are regenerated to match the
+  [#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195) template changes
+  (`Throw.IfNull`, `ReadExactlyCompat`, `AddRangeCompat`) — the Ruby snapshot suite failed on `main`
+  since that merge. The suite now normalizes line endings (so it passes on Windows and Linux alike)
+  and runs in CI via a new `xdr_generator_tests.yml` workflow, so template/snapshot
+  desync can no longer land silently.
+- Cross-TFM behavior parity for the compatibility shims
+  ([#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195) follow-up):
+  - `Util.HexToBytes` (all TFMs) throws `ArgumentNullException` for null and `FormatException` for
+    odd-length input — the `Convert.FromHexString` contract the released package had — instead of
+    `NullReferenceException` / `IndexOutOfRangeException` escaping the decode loop.
+  - The `netstandard2.1` `Throw.IfNullOrEmpty` polyfill emits the BCL's
+    "The value cannot be an empty string." message.
+  - The `netstandard2.1` `ReadAsStringAsync` cancellation shim surfaces `TaskCanceledException`
+    (with the token attached), matching the real net6+ overload, instead of the base
+    `OperationCanceledException`.
+  - The XDR `ReadExactlyCompat` shim throws `EndOfStreamException` with the BCL's
+    "Unable to read beyond the end of the stream." message.
+  - The Sodium key handles used by the `netstandard2.1` Ed25519 backend are disposed after use.
+- `integration_tests.yml` installs both the `8.0.x` and `10.0.x` SDKs; the previous 8-only pin
+  satisfied `global.json` only because the runner image happened to preinstall .NET 10.
+- The README "Platform support" section documents that Unity 2022.3's bundled compiler cannot
+  construct SDK types with `required` members (Unity 6 or an upgraded Roslyn can).

--- a/README.md
+++ b/README.md
@@ -70,14 +70,15 @@ The `stellar-dotnet-sdk` and `stellar-dotnet-sdk-xdr` packages multi-target the 
 |------------------|-------------------|----------------|
 | `net10.0` | .NET 10 apps | NSec |
 | `net8.0` | .NET 8 apps | NSec |
-| `netstandard2.1` | Unity 2022.3+, Unity 6, Tizen 5.5+, portable libraries | Sodium.Core |
+| `netstandard2.1` | Unity 6, Unity 2022.3 (see compiler note below), Tizen 5.5+, portable libraries | Sodium.Core |
 
 NuGet resolves the best matching assembly for your project automatically.
 
 ### TFM-specific API notes
 
 - **SEP-0009 date fields** (`BirthDate`, `IdIssueDate`, `IdExpirationDate`, `RegistrationDate`): `DateOnly?` on `net8.0` / `net10.0`; `string?` (ISO `yyyy-MM-dd`) on `netstandard2.1`. JSON wire format is identical across TFMs.
-- **Synchronous `HttpClient.Send` resilience**: `RetryingHttpMessageHandler` overrides sync `Send` only on `net8.0` / `net10.0`. Use `SendAsync` on `netstandard2.1`.
+- **Synchronous `HttpClient.Send` resilience**: on `net8.0` / `net10.0`, `RetryingHttpMessageHandler` overrides sync `Send` with the full retry pipeline. On the `netstandard2.1` assembly (also what `net5`–`net7` apps resolve), sync `Send` throws `NotSupportedException` instead of silently bypassing retries — use `SendAsync`.
+- **Unity compiler note (`required` members)**: many SDK request/response models declare C# `required` members. Constructing them from *your* code needs a compiler that understands `required`: Unity 6 qualifies; Unity 2022.3's bundled compiler (Roslyn 4.1) does not — member initialization of those types fails to compile there unless you upgrade the compiler (e.g. [UnityRoslynUpdater](https://github.com/DaZombieKiller/UnityRoslynUpdater)). Deserialization and APIs without `required` members are unaffected.
 
 ### Examples
 

--- a/StellarDotnetSdk.Tests/Accounts/KeyPairTest.cs
+++ b/StellarDotnetSdk.Tests/Accounts/KeyPairTest.cs
@@ -36,6 +36,27 @@ public class KeyPairTest
     }
 
     /// <summary>
+    ///     Signing twice with the same KeyPair must produce the identical known-answer signature: the
+    ///     second call goes through the cached Ed25519 signer (expanded once per KeyPair, not per call),
+    ///     which must not change the output.
+    /// </summary>
+    [TestMethod]
+    public void Sign_CalledRepeatedly_ReturnsSameSignatureViaCachedSigner()
+    {
+        const string expectedSig =
+            "587d4b472eeef7d07aafcd0b049640b0bb3f39784118c2e2b73a04fa2f64c9c538b4b2d0f5335e968a480021fdc23e98c0ddf424cb15d8131df8cb6c4bb58309";
+        var keyPair = KeyPair.FromSecretSeed(Util.HexToBytes(Seed));
+        var bytes = Encoding.UTF8.GetBytes("hello world");
+
+        var first = keyPair.Sign(bytes);
+        var second = keyPair.Sign(bytes);
+
+        Assert.IsTrue(Util.HexToBytes(expectedSig).SequenceEqual(first));
+        Assert.IsTrue(first.SequenceEqual(second));
+        Assert.IsTrue(keyPair.Verify(bytes, second));
+    }
+
+    /// <summary>
     ///     Verifies that Verify method returns true for valid signature.
     /// </summary>
     [TestMethod]
@@ -248,5 +269,131 @@ public class KeyPairTest
 
         // Assert
         CollectionAssert.AreEqual(expectedBytes, sig.Hint.InnerValue);
+    }
+
+    /// <summary>
+    ///     Verifies that FromPublicKey rejects a public key that is not exactly 32 bytes at construction time.
+    /// </summary>
+    [DataTestMethod]
+    [DataRow(0)]
+    [DataRow(16)]
+    [DataRow(31)]
+    [DataRow(33)]
+    public void FromPublicKey_WithWrongLengthKey_ThrowsArgumentException(int length)
+    {
+        Assert.ThrowsException<ArgumentException>(() => KeyPair.FromPublicKey(new byte[length]));
+    }
+
+    /// <summary>
+    ///     Verifies that the constructor rejects a null public key.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WithNullPublicKey_ThrowsArgumentNullException()
+    {
+        Assert.ThrowsException<ArgumentNullException>(() => new KeyPair(null!, null, null));
+    }
+
+    /// <summary>
+    ///     Verifies that the constructor rejects a private key that is not exactly 32 bytes at construction time.
+    /// </summary>
+    [DataTestMethod]
+    [DataRow(16)]
+    [DataRow(33)]
+    public void Constructor_WithWrongLengthPrivateKey_ThrowsArgumentException(int length)
+    {
+        var publicKey = KeyPair.FromAccountId("GDEAOZWTVHQZGGJY6KG4NAGJQ6DXATXAJO3AMW7C4IXLKMPWWB4FDNFZ")
+            .PublicKey;
+
+        Assert.ThrowsException<ArgumentException>(() => new KeyPair(publicKey, new byte[length], null));
+    }
+
+    /// <summary>
+    ///     Verifies that the constructor rejects a seed that is not exactly 32 bytes at construction time.
+    /// </summary>
+    [DataTestMethod]
+    [DataRow(16)]
+    [DataRow(33)]
+    public void Constructor_WithWrongLengthSeed_ThrowsArgumentException(int length)
+    {
+        var publicKey = KeyPair.FromAccountId("GDEAOZWTVHQZGGJY6KG4NAGJQ6DXATXAJO3AMW7C4IXLKMPWWB4FDNFZ")
+            .PublicKey;
+
+        Assert.ThrowsException<ArgumentException>(() => new KeyPair(publicKey, null, new byte[length]));
+    }
+
+    /// <summary>
+    ///     Verifies that FromSecretSeed rejects a seed that is not exactly 32 bytes at construction time.
+    /// </summary>
+    [DataTestMethod]
+    [DataRow(0)]
+    [DataRow(16)]
+    [DataRow(31)]
+    [DataRow(33)]
+    public void FromSecretSeed_WithWrongLengthSeed_ThrowsArgumentException(int length)
+    {
+        Assert.ThrowsException<ArgumentException>(() => KeyPair.FromSecretSeed(new byte[length]));
+    }
+
+    /// <summary>
+    ///     Verifies that a KeyPair constructed with a seed but no private key cannot sign.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WithSeedOnly_CannotSign()
+    {
+        // Arrange
+        var publicKey = KeyPair.FromAccountId("GDEAOZWTVHQZGGJY6KG4NAGJQ6DXATXAJO3AMW7C4IXLKMPWWB4FDNFZ")
+            .PublicKey;
+        var unrelatedSeed = Util.HexToBytes(Seed);
+
+        // Act
+        var keyPair = new KeyPair(publicKey, null, unrelatedSeed);
+
+        // Assert
+        Assert.IsFalse(keyPair.CanSign());
+        Assert.IsNull(keyPair.PrivateKey);
+        Assert.IsNotNull(keyPair.SecretSeed);
+        Assert.ThrowsException<Exception>(() => keyPair.Sign(Encoding.UTF8.GetBytes("hello world")));
+    }
+
+    /// <summary>
+    ///     Verifies that a KeyPair constructed with a private key but no seed can sign without exposing a secret seed.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WithPrivateKeyOnly_CanSignWithoutExposingSecretSeed()
+    {
+        // Arrange
+        var privateKey = Util.HexToBytes(Seed);
+        var fullKeyPair = KeyPair.FromSecretSeed(privateKey);
+
+        // Act
+        var keyPair = new KeyPair(fullKeyPair.PublicKey, privateKey, null);
+
+        // Assert
+        Assert.IsTrue(keyPair.CanSign());
+        Assert.IsNotNull(keyPair.PrivateKey);
+        Assert.IsNull(keyPair.SecretSeed);
+        Assert.IsNull(keyPair.SeedBytes);
+        var data = Encoding.UTF8.GetBytes("hello world");
+        Assert.IsTrue(keyPair.Verify(data, keyPair.Sign(data)));
+    }
+
+    /// <summary>
+    ///     Verifies that a KeyPair holding only a private key equals a public-only KeyPair with the same public key,
+    ///     since neither holds a secret seed.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WithPrivateKeyOnlyAndPublicOnly_ReturnsTrue()
+    {
+        // Arrange
+        var privateKey = Util.HexToBytes(Seed);
+        var fullKeyPair = KeyPair.FromSecretSeed(privateKey);
+
+        // Act
+        var keyPair = new KeyPair(fullKeyPair.PublicKey, privateKey, null);
+        var publicOnlyKeyPair = KeyPair.FromPublicKey(fullKeyPair.PublicKey);
+
+        // Assert
+        Assert.IsTrue(keyPair.Equals(publicOnlyKeyPair));
+        Assert.IsTrue(publicOnlyKeyPair.Equals(keyPair));
     }
 }

--- a/StellarDotnetSdk.Tests/Compatibility/CompatibilityParityTest.cs
+++ b/StellarDotnetSdk.Tests/Compatibility/CompatibilityParityTest.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StellarDotnetSdk.Compatibility;
+
+namespace StellarDotnetSdk.Tests.Compatibility;
+
+/// <summary>
+///     Cross-TFM parity tests for the netstandard2.1 compatibility helpers: the polyfills must surface the
+///     same exception types and messages as the BCL members they stand in for, so consumers observe identical
+///     behavior no matter which assembly NuGet resolves. These run on every test leg — on net8.0/net10.0 they
+///     pin the BCL behavior the polyfills mirror; on the netstandard2.1 leg they exercise the polyfills.
+/// </summary>
+[TestClass]
+public class CompatibilityParityTest
+{
+    [TestMethod]
+    public void ThrowIfNullOrEmpty_WithEmptyString_MatchesBclMessageAndParamName()
+    {
+        var ex = Assert.ThrowsException<ArgumentException>(() => Throw.IfNullOrEmpty("", "value"));
+
+        Assert.AreEqual("value", ex.ParamName);
+        StringAssert.StartsWith(ex.Message, "The value cannot be an empty string.");
+    }
+
+    [TestMethod]
+    public void ThrowIfNullOrEmpty_WithNull_ThrowsArgumentNullException()
+    {
+        var ex = Assert.ThrowsException<ArgumentNullException>(() => Throw.IfNullOrEmpty(null, "value"));
+
+        Assert.AreEqual("value", ex.ParamName);
+    }
+
+#if TEST_SDK_NETSTANDARD21
+    /// <summary>
+    ///     The netstandard2.1 ReadAsStringAsync shim must surface cancellation as TaskCanceledException —
+    ///     the type the real HttpContent.ReadAsStringAsync(CancellationToken) overload throws on net8.0+ —
+    ///     so a consumer's <c>catch (TaskCanceledException)</c> behaves identically across TFMs.
+    /// </summary>
+    [TestMethod]
+    public async Task ReadAsStringAsyncShim_PreCanceledToken_ThrowsTaskCanceledException()
+    {
+        using var content = new StringContent("body");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var ex = await Assert.ThrowsExceptionAsync<TaskCanceledException>(() =>
+            HttpContentExtensions.ReadAsStringAsync(content, cts.Token));
+        Assert.AreEqual(cts.Token, ex.CancellationToken);
+    }
+
+    /// <summary>
+    ///     Same parity for the mid-read cancellation path: the shim races the body read against the token,
+    ///     and losing that race must also surface as TaskCanceledException, not the base
+    ///     OperationCanceledException.
+    /// </summary>
+    [TestMethod]
+    public async Task ReadAsStringAsyncShim_CanceledMidRead_ThrowsTaskCanceledException()
+    {
+        using var content = new NeverCompletingContent();
+        using var cts = new CancellationTokenSource();
+
+        var readTask = HttpContentExtensions.ReadAsStringAsync(content, cts.Token);
+        cts.Cancel();
+
+        var ex = await Assert.ThrowsExceptionAsync<TaskCanceledException>(() => readTask);
+        Assert.AreEqual(cts.Token, ex.CancellationToken);
+    }
+
+    private sealed class NeverCompletingContent : HttpContent
+    {
+        private readonly TaskCompletionSource<bool> _never = new();
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+        {
+            return _never.Task;
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
+    }
+#endif
+}

--- a/StellarDotnetSdk.Tests/Requests/RetryingHttpMessageHandlerTests.cs
+++ b/StellarDotnetSdk.Tests/Requests/RetryingHttpMessageHandlerTests.cs
@@ -974,6 +974,27 @@ public class RetryingHttpMessageHandlerTests
 #endif
 
     /// <summary>
+    ///     On the netstandard2.1 assembly the handler derives from HttpMessageHandler (not DelegatingHandler),
+    ///     so synchronous HttpClient.Send must fail loudly with NotSupportedException on net5+ hosts instead
+    ///     of silently bypassing the resilience pipeline — the bypass a DelegatingHandler base would cause.
+    /// </summary>
+#if TEST_SDK_NETSTANDARD21
+    [TestMethod]
+    public void Send_SynchronousPath_ThrowsNotSupportedInsteadOfBypassingPipeline()
+    {
+        var handler = new TrackingHttpMessageHandler((_, _, _) =>
+            Task.FromResult(CreateResponse(HttpStatusCode.OK)));
+
+        using var retryHandler = new RetryingHttpMessageHandler(handler, new HttpResilienceOptions());
+        using var client = new HttpClient(retryHandler);
+
+        Assert.ThrowsException<NotSupportedException>(() =>
+            client.Send(new HttpRequestMessage(HttpMethod.Get, TestUri)));
+        Assert.AreEqual(0, handler.CallCount); // the request never silently reached the inner handler
+    }
+#endif
+
+    /// <summary>
     ///     Circuit-breaker failure counting is not limited by the RetryHttpMethods whitelist: a sustained
     ///     503 storm on POST (not retried — replay safety) must still open the circuit.
     /// </summary>

--- a/StellarDotnetSdk.Tests/Sep/Sep0009/KycJsonSerializationTest.cs
+++ b/StellarDotnetSdk.Tests/Sep/Sep0009/KycJsonSerializationTest.cs
@@ -34,12 +34,10 @@ public class KycJsonSerializationTest
         fields.IdIssueDate.Should().Be(KycTestDates.IdIssueDate);
         fields.IdExpirationDate.Should().Be(KycTestDates.IdExpirationDate);
 
-#if !TEST_SDK_NETSTANDARD21
         var roundTrip = JsonSerializer.Serialize(fields, KycJsonOptions.Default);
         roundTrip.Should().Contain("\"birthDate\":\"1990-01-15\"");
         roundTrip.Should().Contain("\"idIssueDate\":\"2020-05-10\"");
         roundTrip.Should().Contain("\"idExpirationDate\":\"2030-05-10\"");
-#endif
     }
 
     [TestMethod]
@@ -58,10 +56,8 @@ public class KycJsonSerializationTest
         fields!.Name.Should().Be("Acme Corp");
         fields.RegistrationDate.Should().Be(KycTestDates.RegistrationDateIso);
 
-#if !TEST_SDK_NETSTANDARD21
         var roundTrip = JsonSerializer.Serialize(fields, KycJsonOptions.Default);
         roundTrip.Should().Contain("\"registrationDate\":\"2020-01-15\"");
-#endif
     }
 
     [TestMethod]
@@ -85,7 +81,6 @@ public class KycJsonSerializationTest
         fields.Organization!.RegistrationDate.Should().Be(KycTestDates.NestedRegistrationDate);
     }
 
-#if NET8_0_OR_GREATER && !TEST_SDK_NETSTANDARD21
     [TestMethod]
     public void JsonOptions_DefaultOptions_IsReadOnly()
     {
@@ -98,6 +93,7 @@ public class KycJsonSerializationTest
         KycJsonOptions.Default.IsReadOnly.Should().BeTrue();
     }
 
+#if !TEST_SDK_NETSTANDARD21
     [TestMethod]
     public void NullableDateOnlyJsonConverter_RejectsInvalidDateFormat()
     {
@@ -106,6 +102,49 @@ public class KycJsonSerializationTest
         var act = () => JsonSerializer.Deserialize<NaturalPersonKycFields>(json, KycJsonOptions.Default);
 
         act.Should().Throw<JsonException>();
+    }
+#endif
+
+#if TEST_SDK_NETSTANDARD21
+    [TestMethod]
+    public void IsoDateStringJsonConverter_RejectsInvalidDateFormat_OnRead()
+    {
+        var json = """{"birthDate":"15-01-1990"}""";
+
+        var act = () => JsonSerializer.Deserialize<NaturalPersonKycFields>(json, KycJsonOptions.Default);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [TestMethod]
+    public void IsoDateStringJsonConverter_RejectsInvalidRegistrationDate_OnRead()
+    {
+        var json = """{"registrationDate":"June 1, 2010"}""";
+
+        var act = () => JsonSerializer.Deserialize<OrganizationKycFields>(json, KycJsonOptions.Default);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [TestMethod]
+    public void IsoDateStringJsonConverter_RejectsInvalidDateFormat_OnWrite()
+    {
+        var fields = new NaturalPersonKycFields { BirthDate = "6/9/2026" };
+
+        var act = () => JsonSerializer.Serialize(fields, KycJsonOptions.Default);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [TestMethod]
+    public void IsoDateStringJsonConverter_AllowsNullDates()
+    {
+        var fields = new NaturalPersonKycFields { FirstName = "John" };
+
+        var json = JsonSerializer.Serialize(fields, KycJsonOptions.Default);
+        var roundTrip = JsonSerializer.Deserialize<NaturalPersonKycFields>(json, KycJsonOptions.Default);
+
+        roundTrip!.BirthDate.Should().BeNull();
     }
 #endif
 }

--- a/StellarDotnetSdk.Tests/UtilTest.cs
+++ b/StellarDotnetSdk.Tests/UtilTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -27,6 +28,41 @@ public class UtilTest
 
         // Assert
         Assert.AreEqual(test, bytesToString);
+    }
+
+    /// <summary>
+    ///     HexToBytes must keep the exception contract of <c>Convert.FromHexString</c> (which the released
+    ///     package used): ArgumentNullException for null, FormatException for odd-length or non-hex input —
+    ///     not NullReferenceException / IndexOutOfRangeException from the decode loop.
+    /// </summary>
+    [TestMethod]
+    public void HexToBytes_WithNull_ThrowsArgumentNullException()
+    {
+        Assert.ThrowsException<ArgumentNullException>(() => Util.HexToBytes(null!));
+    }
+
+    [TestMethod]
+    public void HexToBytes_WithOddLength_ThrowsFormatException()
+    {
+        Assert.ThrowsException<FormatException>(() => Util.HexToBytes("abc"));
+    }
+
+    [TestMethod]
+    public void HexToBytes_WithInvalidCharacter_ThrowsFormatException()
+    {
+        Assert.ThrowsException<FormatException>(() => Util.HexToBytes("zz11"));
+    }
+
+    [TestMethod]
+    public void HexToBytes_WithMixedCase_Decodes()
+    {
+        CollectionAssert.AreEqual(new byte[] { 0xAB, 0xCD }, Util.HexToBytes("aBcD"));
+    }
+
+    [TestMethod]
+    public void HexToBytes_WithEmptyString_ReturnsEmptyArray()
+    {
+        Assert.AreEqual(0, Util.HexToBytes(string.Empty).Length);
     }
 
     /// <summary>

--- a/StellarDotnetSdk.Tests/Xdr/XdrDataStreamTest.cs
+++ b/StellarDotnetSdk.Tests/Xdr/XdrDataStreamTest.cs
@@ -14,6 +14,20 @@ namespace StellarDotnetSdk.Tests.Xdr;
 [TestClass]
 public class XdrDataStreamTest
 {
+    /// <summary>
+    ///     A truncated stream must fail with the BCL's Stream.ReadExactly exception type and message on
+    ///     every TFM: net8.0/net10.0 call ReadExactly directly, and the netstandard2.1 compat shim mirrors
+    ///     it, so consumers matching on either observe identical behavior.
+    /// </summary>
+    [TestMethod]
+    public void ReadInt_WithTruncatedStream_ThrowsEndOfStreamWithBclMessage()
+    {
+        var stream = new XdrDataInputStream(new byte[2]);
+
+        var ex = Assert.ThrowsException<EndOfStreamException>(() => stream.ReadInt());
+        Assert.AreEqual("Unable to read beyond the end of the stream.", ex.Message);
+    }
+
     private static string BackAndForthXdrStreaming(string inputString)
     {
         var xdrOutputStream = new XdrDataOutputStream();

--- a/StellarDotnetSdk.Xdr/Compatibility/NetstandardCompat.cs
+++ b/StellarDotnetSdk.Xdr/Compatibility/NetstandardCompat.cs
@@ -27,8 +27,9 @@ internal static class NetstandardCompat
             var read = stream.Read(buffer.Slice(totalRead));
             if (read <= 0)
             {
-                throw new EndOfStreamException(
-                    $"Unable to read required number of bytes. Expected {buffer.Length}, got {totalRead}.");
+                // Same text as Stream.ReadExactly's EndOfStreamException on net8.0+, so callers matching
+                // on the message observe identical behavior across target frameworks.
+                throw new EndOfStreamException("Unable to read beyond the end of the stream.");
             }
 
             totalRead += read;

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/generator_snapshot_test.rb
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/generator_snapshot_test.rb
@@ -40,7 +40,7 @@ class GeneratorSnapshotTest < Minitest::Test
       if UPDATE_SNAPSHOTS
         FileUtils.rm_rf(snapshot_dir)
         FileUtils.mkdir_p(snapshot_dir)
-        FileUtils.cp_r("#{generated_dir}/.", snapshot_dir)
+        copy_normalized(generated_dir, snapshot_dir)
         next
       end
 
@@ -76,8 +76,8 @@ class GeneratorSnapshotTest < Minitest::Test
     expected_files.each do |relative_path|
       expected_path = File.join(expected_dir, relative_path)
       actual_path = File.join(actual_dir, relative_path)
-      expected_content = File.binread(expected_path)
-      actual_content = File.binread(actual_path)
+      expected_content = normalize_eol(File.binread(expected_path))
+      actual_content = normalize_eol(File.binread(actual_path))
 
       assert_equal expected_content, actual_content, <<~MSG
         Generated content changed for fixture #{fixture_name}: #{relative_path}
@@ -89,5 +89,20 @@ class GeneratorSnapshotTest < Minitest::Test
     Dir.chdir(root_dir) do
       Dir.glob("**/*", File::FNM_DOTMATCH).sort.select { |path| File.file?(path) }
     end
+  end
+
+  # Generation emits platform-native line endings (CRLF on Windows); snapshots
+  # are stored with LF so the suite passes on every OS.
+  def copy_normalized(source_dir, target_dir)
+    collect_relative_files(source_dir).each do |relative_path|
+      source_path = File.join(source_dir, relative_path)
+      target_path = File.join(target_dir, relative_path)
+      FileUtils.mkdir_p(File.dirname(target_path))
+      File.binwrite(target_path, normalize_eol(File.binread(source_path)))
+    end
+  end
+
+  def normalize_eol(content)
+    content.gsub("\r\n", "\n")
   end
 end

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/block_comments/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/block_comments/XdrDataInputStream.cs
@@ -6,6 +6,7 @@ using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace StellarDotnetSdk.Xdr;
 
@@ -25,7 +26,7 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
-        ArgumentNullException.ThrowIfNull(bytes);
+        Throw.IfNull(bytes, nameof(bytes));
         _bytes = bytes;
         _stream = new MemoryStream(bytes, false);
     }
@@ -37,7 +38,7 @@ public class XdrDataInputStream
     public byte Read()
     {
         Span<byte> buffer = stackalloc byte[1];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return buffer[0];
     }
 
@@ -85,14 +86,14 @@ public class XdrDataInputStream
     internal long ReadLong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
@@ -103,7 +104,7 @@ public class XdrDataInputStream
     public int ReadInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
@@ -114,7 +115,7 @@ public class XdrDataInputStream
     public uint ReadUInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
@@ -221,7 +222,7 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        _stream.ReadExactly(result);
+        _stream.ReadExactlyCompat(result);
 
         if (tail == 0)
         {
@@ -229,7 +230,7 @@ public class XdrDataInputStream
         }
 
         var tailBytes = new byte[tailLength];
-        _stream.ReadExactly(tailBytes);
+        _stream.ReadExactlyCompat(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/block_comments/XdrDataOutputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/block_comments/XdrDataOutputStream.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace StellarDotnetSdk.Xdr;
 
@@ -69,28 +70,28 @@ public class XdrDataOutputStream
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
         BinaryPrimitives.WriteInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteULong(ulong v)
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
         BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteInt(int i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
         BinaryPrimitives.WriteInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteUInt(uint i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
         BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteSingle(float v)

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/const/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/const/XdrDataInputStream.cs
@@ -6,6 +6,7 @@ using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace StellarDotnetSdk.Xdr;
 
@@ -25,7 +26,7 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
-        ArgumentNullException.ThrowIfNull(bytes);
+        Throw.IfNull(bytes, nameof(bytes));
         _bytes = bytes;
         _stream = new MemoryStream(bytes, false);
     }
@@ -37,7 +38,7 @@ public class XdrDataInputStream
     public byte Read()
     {
         Span<byte> buffer = stackalloc byte[1];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return buffer[0];
     }
 
@@ -85,14 +86,14 @@ public class XdrDataInputStream
     internal long ReadLong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
@@ -103,7 +104,7 @@ public class XdrDataInputStream
     public int ReadInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
@@ -114,7 +115,7 @@ public class XdrDataInputStream
     public uint ReadUInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
@@ -221,7 +222,7 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        _stream.ReadExactly(result);
+        _stream.ReadExactlyCompat(result);
 
         if (tail == 0)
         {
@@ -229,7 +230,7 @@ public class XdrDataInputStream
         }
 
         var tailBytes = new byte[tailLength];
-        _stream.ReadExactly(tailBytes);
+        _stream.ReadExactlyCompat(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/const/XdrDataOutputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/const/XdrDataOutputStream.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace StellarDotnetSdk.Xdr;
 
@@ -69,28 +70,28 @@ public class XdrDataOutputStream
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
         BinaryPrimitives.WriteInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteULong(ulong v)
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
         BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteInt(int i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
         BinaryPrimitives.WriteInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteUInt(uint i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
         BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteSingle(float v)

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/enum/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/enum/XdrDataInputStream.cs
@@ -6,6 +6,7 @@ using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace StellarDotnetSdk.Xdr;
 
@@ -25,7 +26,7 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
-        ArgumentNullException.ThrowIfNull(bytes);
+        Throw.IfNull(bytes, nameof(bytes));
         _bytes = bytes;
         _stream = new MemoryStream(bytes, false);
     }
@@ -37,7 +38,7 @@ public class XdrDataInputStream
     public byte Read()
     {
         Span<byte> buffer = stackalloc byte[1];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return buffer[0];
     }
 
@@ -85,14 +86,14 @@ public class XdrDataInputStream
     internal long ReadLong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
@@ -103,7 +104,7 @@ public class XdrDataInputStream
     public int ReadInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
@@ -114,7 +115,7 @@ public class XdrDataInputStream
     public uint ReadUInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
@@ -221,7 +222,7 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        _stream.ReadExactly(result);
+        _stream.ReadExactlyCompat(result);
 
         if (tail == 0)
         {
@@ -229,7 +230,7 @@ public class XdrDataInputStream
         }
 
         var tailBytes = new byte[tailLength];
-        _stream.ReadExactly(tailBytes);
+        _stream.ReadExactlyCompat(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/enum/XdrDataOutputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/enum/XdrDataOutputStream.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace StellarDotnetSdk.Xdr;
 
@@ -69,28 +70,28 @@ public class XdrDataOutputStream
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
         BinaryPrimitives.WriteInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteULong(ulong v)
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
         BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteInt(int i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
         BinaryPrimitives.WriteInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteUInt(uint i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
         BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteSingle(float v)

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/nesting/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/nesting/XdrDataInputStream.cs
@@ -6,6 +6,7 @@ using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace StellarDotnetSdk.Xdr;
 
@@ -25,7 +26,7 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
-        ArgumentNullException.ThrowIfNull(bytes);
+        Throw.IfNull(bytes, nameof(bytes));
         _bytes = bytes;
         _stream = new MemoryStream(bytes, false);
     }
@@ -37,7 +38,7 @@ public class XdrDataInputStream
     public byte Read()
     {
         Span<byte> buffer = stackalloc byte[1];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return buffer[0];
     }
 
@@ -85,14 +86,14 @@ public class XdrDataInputStream
     internal long ReadLong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
@@ -103,7 +104,7 @@ public class XdrDataInputStream
     public int ReadInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
@@ -114,7 +115,7 @@ public class XdrDataInputStream
     public uint ReadUInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
@@ -221,7 +222,7 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        _stream.ReadExactly(result);
+        _stream.ReadExactlyCompat(result);
 
         if (tail == 0)
         {
@@ -229,7 +230,7 @@ public class XdrDataInputStream
         }
 
         var tailBytes = new byte[tailLength];
-        _stream.ReadExactly(tailBytes);
+        _stream.ReadExactlyCompat(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/nesting/XdrDataOutputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/nesting/XdrDataOutputStream.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace StellarDotnetSdk.Xdr;
 
@@ -69,28 +70,28 @@ public class XdrDataOutputStream
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
         BinaryPrimitives.WriteInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteULong(ulong v)
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
         BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteInt(int i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
         BinaryPrimitives.WriteInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteUInt(uint i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
         BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteSingle(float v)

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/optional/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/optional/XdrDataInputStream.cs
@@ -6,6 +6,7 @@ using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace StellarDotnetSdk.Xdr;
 
@@ -25,7 +26,7 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
-        ArgumentNullException.ThrowIfNull(bytes);
+        Throw.IfNull(bytes, nameof(bytes));
         _bytes = bytes;
         _stream = new MemoryStream(bytes, false);
     }
@@ -37,7 +38,7 @@ public class XdrDataInputStream
     public byte Read()
     {
         Span<byte> buffer = stackalloc byte[1];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return buffer[0];
     }
 
@@ -85,14 +86,14 @@ public class XdrDataInputStream
     internal long ReadLong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
@@ -103,7 +104,7 @@ public class XdrDataInputStream
     public int ReadInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
@@ -114,7 +115,7 @@ public class XdrDataInputStream
     public uint ReadUInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
@@ -221,7 +222,7 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        _stream.ReadExactly(result);
+        _stream.ReadExactlyCompat(result);
 
         if (tail == 0)
         {
@@ -229,7 +230,7 @@ public class XdrDataInputStream
         }
 
         var tailBytes = new byte[tailLength];
-        _stream.ReadExactly(tailBytes);
+        _stream.ReadExactlyCompat(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/optional/XdrDataOutputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/optional/XdrDataOutputStream.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace StellarDotnetSdk.Xdr;
 
@@ -69,28 +70,28 @@ public class XdrDataOutputStream
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
         BinaryPrimitives.WriteInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteULong(ulong v)
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
         BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteInt(int i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
         BinaryPrimitives.WriteInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteUInt(uint i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
         BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteSingle(float v)

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/struct/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/struct/XdrDataInputStream.cs
@@ -6,6 +6,7 @@ using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace StellarDotnetSdk.Xdr;
 
@@ -25,7 +26,7 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
-        ArgumentNullException.ThrowIfNull(bytes);
+        Throw.IfNull(bytes, nameof(bytes));
         _bytes = bytes;
         _stream = new MemoryStream(bytes, false);
     }
@@ -37,7 +38,7 @@ public class XdrDataInputStream
     public byte Read()
     {
         Span<byte> buffer = stackalloc byte[1];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return buffer[0];
     }
 
@@ -85,14 +86,14 @@ public class XdrDataInputStream
     internal long ReadLong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
@@ -103,7 +104,7 @@ public class XdrDataInputStream
     public int ReadInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
@@ -114,7 +115,7 @@ public class XdrDataInputStream
     public uint ReadUInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
@@ -221,7 +222,7 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        _stream.ReadExactly(result);
+        _stream.ReadExactlyCompat(result);
 
         if (tail == 0)
         {
@@ -229,7 +230,7 @@ public class XdrDataInputStream
         }
 
         var tailBytes = new byte[tailLength];
-        _stream.ReadExactly(tailBytes);
+        _stream.ReadExactlyCompat(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/struct/XdrDataOutputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/struct/XdrDataOutputStream.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace StellarDotnetSdk.Xdr;
 
@@ -69,28 +70,28 @@ public class XdrDataOutputStream
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
         BinaryPrimitives.WriteInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteULong(ulong v)
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
         BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteInt(int i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
         BinaryPrimitives.WriteInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteUInt(uint i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
         BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteSingle(float v)

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/test/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/test/XdrDataInputStream.cs
@@ -6,6 +6,7 @@ using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace StellarDotnetSdk.Xdr;
 
@@ -25,7 +26,7 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
-        ArgumentNullException.ThrowIfNull(bytes);
+        Throw.IfNull(bytes, nameof(bytes));
         _bytes = bytes;
         _stream = new MemoryStream(bytes, false);
     }
@@ -37,7 +38,7 @@ public class XdrDataInputStream
     public byte Read()
     {
         Span<byte> buffer = stackalloc byte[1];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return buffer[0];
     }
 
@@ -85,14 +86,14 @@ public class XdrDataInputStream
     internal long ReadLong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
@@ -103,7 +104,7 @@ public class XdrDataInputStream
     public int ReadInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
@@ -114,7 +115,7 @@ public class XdrDataInputStream
     public uint ReadUInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
@@ -221,7 +222,7 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        _stream.ReadExactly(result);
+        _stream.ReadExactlyCompat(result);
 
         if (tail == 0)
         {
@@ -229,7 +230,7 @@ public class XdrDataInputStream
         }
 
         var tailBytes = new byte[tailLength];
-        _stream.ReadExactly(tailBytes);
+        _stream.ReadExactlyCompat(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/test/XdrDataOutputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/test/XdrDataOutputStream.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace StellarDotnetSdk.Xdr;
 
@@ -69,28 +70,28 @@ public class XdrDataOutputStream
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
         BinaryPrimitives.WriteInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteULong(ulong v)
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
         BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteInt(int i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
         BinaryPrimitives.WriteInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteUInt(uint i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
         BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteSingle(float v)

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/union/XdrDataInputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/union/XdrDataInputStream.cs
@@ -6,6 +6,7 @@ using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace StellarDotnetSdk.Xdr;
 
@@ -25,7 +26,7 @@ public class XdrDataInputStream
     /// <param name="bytes"></param>
     public XdrDataInputStream(byte[] bytes)
     {
-        ArgumentNullException.ThrowIfNull(bytes);
+        Throw.IfNull(bytes, nameof(bytes));
         _bytes = bytes;
         _stream = new MemoryStream(bytes, false);
     }
@@ -37,7 +38,7 @@ public class XdrDataInputStream
     public byte Read()
     {
         Span<byte> buffer = stackalloc byte[1];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return buffer[0];
     }
 
@@ -85,14 +86,14 @@ public class XdrDataInputStream
     internal long ReadLong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt64BigEndian(buffer);
     }
 
     internal ulong ReadULong()
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt64BigEndian(buffer);
     }
 
@@ -103,7 +104,7 @@ public class XdrDataInputStream
     public int ReadInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadInt32BigEndian(buffer);
     }
 
@@ -114,7 +115,7 @@ public class XdrDataInputStream
     public uint ReadUInt()
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        _stream.ReadExactly(buffer);
+        _stream.ReadExactlyCompat(buffer);
         return BinaryPrimitives.ReadUInt32BigEndian(buffer);
     }
 
@@ -221,7 +222,7 @@ public class XdrDataInputStream
         }
 
         var result = new byte[len];
-        _stream.ReadExactly(result);
+        _stream.ReadExactlyCompat(result);
 
         if (tail == 0)
         {
@@ -229,7 +230,7 @@ public class XdrDataInputStream
         }
 
         var tailBytes = new byte[tailLength];
-        _stream.ReadExactly(tailBytes);
+        _stream.ReadExactlyCompat(tailBytes);
 
         if (tailBytes.Any(a => a != 0))
         {

--- a/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/union/XdrDataOutputStream.cs
+++ b/StellarDotnetSdk.Xdr/xdr-generator/test/snapshots/union/XdrDataOutputStream.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
+using StellarDotnetSdk.Xdr.Compatibility;
 
 namespace StellarDotnetSdk.Xdr;
 
@@ -69,28 +70,28 @@ public class XdrDataOutputStream
     {
         Span<byte> buffer = stackalloc byte[sizeof(long)];
         BinaryPrimitives.WriteInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteULong(ulong v)
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
         BinaryPrimitives.WriteUInt64BigEndian(buffer, v);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteInt(int i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(int)];
         BinaryPrimitives.WriteInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteUInt(uint i)
     {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
         BinaryPrimitives.WriteUInt32BigEndian(buffer, i);
-        _bytes.AddRange(buffer);
+        _bytes.AddRangeCompat(buffer);
     }
 
     public void WriteSingle(float v)

--- a/StellarDotnetSdk/Accounts/KeyPair.cs
+++ b/StellarDotnetSdk/Accounts/KeyPair.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text.Json.Serialization;
+using System.Threading;
 using dotnetstandard_bip32;
 using StellarDotnetSdk.Crypto;
 using StellarDotnetSdk.Converters;
@@ -25,10 +26,18 @@ public class KeyPair : IAccountId, IEquatable<KeyPair>
 {
     private readonly byte[] _publicKey;
 
+    private readonly byte[]? _privateKey;
+
+    // Lazily created on first Sign and reused, so the Ed25519 key expansion/import runs once per KeyPair
+    // instead of once per signature (roughly a 2x cost per signature otherwise).
+    private Ed25519Signer? _signer;
+
     /// <summary>
     ///     Creates a new Keypair object from public key.
     /// </summary>
-    /// <param name="publicKey"></param>
+    /// <param name="publicKey">The 32-byte ed25519 public key.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="publicKey" /> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="publicKey" /> is not exactly 32 bytes long.</exception>
     public KeyPair(byte[] publicKey)
         : this(publicKey, null, null)
     {
@@ -38,22 +47,39 @@ public class KeyPair : IAccountId, IEquatable<KeyPair>
     ///     Creates a new Keypair instance from secret. This can either be secret key or secret seed depending on underlying
     ///     public-key signature system. Currently Keypair only supports ed25519.
     /// </summary>
-    /// <param name="publicKey"></param>
-    /// <param name="privateKey"></param>
-    /// <param name="seed"></param>
+    /// <param name="publicKey">The 32-byte ed25519 public key.</param>
+    /// <param name="privateKey">The optional 32-byte raw private key; enables signing when provided.</param>
+    /// <param name="seed">The optional 32-byte secret seed, exposed via <see cref="SeedBytes" /> and <see cref="SecretSeed" />.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="publicKey" /> is null.</exception>
+    /// <exception cref="ArgumentException">
+    ///     Thrown when <paramref name="publicKey" />, <paramref name="privateKey" /> or <paramref name="seed" />
+    ///     is not exactly 32 bytes long.
+    /// </exception>
     public KeyPair(byte[] publicKey, byte[]? privateKey, byte[]? seed)
     {
         if (publicKey == null) throw new ArgumentNullException(nameof(publicKey));
+        if (publicKey.Length != Ed25519.PublicKeyLength)
+        {
+            throw new ArgumentException($"PublicKey must be {Ed25519.PublicKeyLength} bytes.", nameof(publicKey));
+        }
+        if (privateKey != null && privateKey.Length != Ed25519.SeedLength)
+        {
+            throw new ArgumentException($"PrivateKey must be {Ed25519.SeedLength} bytes.", nameof(privateKey));
+        }
+        if (seed != null && seed.Length != Ed25519.SeedLength)
+        {
+            throw new ArgumentException($"Seed must be {Ed25519.SeedLength} bytes.", nameof(seed));
+        }
 
         _publicKey = (byte[])publicKey.Clone();
-        var secret = seed ?? privateKey;
-        SeedBytes = secret != null ? (byte[])secret.Clone() : null;
+        _privateKey = privateKey != null ? (byte[])privateKey.Clone() : null;
+        SeedBytes = seed != null ? (byte[])seed.Clone() : null;
     }
 
     /// <summary>
     ///     The private key.
     /// </summary>
-    public byte[]? PrivateKey => SeedBytes is null ? null : (byte[])SeedBytes.Clone();
+    public byte[]? PrivateKey => _privateKey is null ? null : (byte[])_privateKey.Clone();
 
     /// <summary>
     ///     The bytes of the Secret Seed
@@ -224,7 +250,7 @@ public class KeyPair : IAccountId, IEquatable<KeyPair>
     /// <returns></returns>
     public bool CanSign()
     {
-        return SeedBytes != null;
+        return _privateKey != null;
     }
 
     /// <summary>
@@ -247,6 +273,8 @@ public class KeyPair : IAccountId, IEquatable<KeyPair>
     /// <returns>
     ///     <see cref="KeyPair" />
     /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="seed" /> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="seed" /> is not exactly 32 bytes long.</exception>
     public static KeyPair FromSecretSeed(byte[] seed)
     {
         var publicKey = Ed25519.GetPublicKey(seed);
@@ -301,6 +329,8 @@ public class KeyPair : IAccountId, IEquatable<KeyPair>
     /// <returns>
     ///     <see cref="KeyPair" />
     /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="publicKey" /> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="publicKey" /> is not exactly 32 bytes long.</exception>
     public static KeyPair FromPublicKey(byte[] publicKey)
     {
         return new KeyPair(publicKey);
@@ -325,16 +355,26 @@ public class KeyPair : IAccountId, IEquatable<KeyPair>
     ///     Sign the provided data with the key pair's private key.
     /// </summary>
     /// <param name="data">The data to sign.</param>
-    /// <returns>signed bytes, null if the private key for this keypair is null.</returns>
+    /// <returns>The signed bytes.</returns>
+    /// <exception cref="Exception">Thrown when this keypair does not contain a private key.</exception>
     public byte[] Sign(byte[] data)
     {
-        if (SeedBytes == null)
+        if (_privateKey == null)
         {
             throw new Exception(
                 "KeyPair does not contain secret key. Use KeyPair.fromSecretSeed method to create a new KeyPair with a secret key.");
         }
 
-        return Ed25519.Sign(SeedBytes, data);
+        var signer = Volatile.Read(ref _signer);
+        if (signer == null)
+        {
+            signer = new Ed25519Signer(_privateKey);
+            // Benign race: if two threads initialize concurrently, the first published instance wins and
+            // both are functionally identical; the loser is simply collected.
+            signer = Interlocked.CompareExchange(ref _signer, signer, null) ?? signer;
+        }
+
+        return signer.Sign(data);
     }
 
     /// <summary>

--- a/StellarDotnetSdk/Compatibility/HttpContentExtensions.cs
+++ b/StellarDotnetSdk/Compatibility/HttpContentExtensions.cs
@@ -9,7 +9,14 @@ internal static class HttpContentExtensions
 {
     public static async Task<string> ReadAsStringAsync(this HttpContent content, CancellationToken cancellationToken)
     {
-        cancellationToken.ThrowIfCancellationRequested();
+        if (cancellationToken.IsCancellationRequested)
+        {
+            // Match the real ReadAsStringAsync(CancellationToken) overload on net8.0+, which surfaces
+            // cancellation as TaskCanceledException (with the token attached), not the base
+            // OperationCanceledException that ThrowIfCancellationRequested would produce.
+            return await Task.FromCanceled<string>(cancellationToken).ConfigureAwait(false);
+        }
+
         if (!cancellationToken.CanBeCanceled)
         {
             return await content.ReadAsStringAsync().ConfigureAwait(false);
@@ -26,7 +33,8 @@ internal static class HttpContentExtensions
             {
                 // Observe the eventual read result/exception so it is not left unobserved.
                 _ = readTask.ContinueWith(static t => _ = t.Exception, TaskContinuationOptions.OnlyOnFaulted);
-                cancellationToken.ThrowIfCancellationRequested();
+                // TaskCanceledException for type parity with the net8.0+ overload (see above).
+                return await Task.FromCanceled<string>(cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/StellarDotnetSdk/Compatibility/Throw.cs
+++ b/StellarDotnetSdk/Compatibility/Throw.cs
@@ -26,7 +26,9 @@ internal static class Throw
 
         if (value.Length == 0)
         {
-            throw new ArgumentException("Value cannot be empty.", paramName);
+            // Same text as ArgumentException.ThrowIfNullOrEmpty on net8.0+, so exception messages
+            // do not diverge between target frameworks.
+            throw new ArgumentException("The value cannot be an empty string.", paramName);
         }
 #else
         ArgumentException.ThrowIfNullOrEmpty(value, paramName);

--- a/StellarDotnetSdk/Converters/IsoDateStringJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/IsoDateStringJsonConverter.cs
@@ -1,0 +1,62 @@
+#if NETSTANDARD2_1
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace StellarDotnetSdk.Converters;
+
+/// <summary>
+///     Validates string-typed date properties as ISO 8601 date-only strings (yyyy-MM-dd), matching SEP-0009.
+///     This is the netstandard2.1 counterpart of <c>NullableDateOnlyJsonConverter</c>: on frameworks without
+///     <c>DateOnly</c>, date fields are plain strings, and this converter rejects any value that is not a valid
+///     yyyy-MM-dd date on both read and write so all target frameworks accept and emit identical JSON.
+///     Kept <c>internal</c>: it is applied via <c>[JsonConverter(typeof(...))]</c> within this assembly and
+///     must not add a public type to the netstandard2.1 surface that the net8.0/net10.0 builds lack
+///     (cross-TFM package-validation, CP0001).
+/// </summary>
+internal sealed class IsoDateStringJsonConverter : JsonConverter<string?>
+{
+    internal const string IsoDateFormat = "yyyy-MM-dd";
+
+    /// <inheritdoc />
+    public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return null;
+        }
+
+        var value = reader.GetString();
+        if (value is null)
+        {
+            return null;
+        }
+
+        Validate(value);
+        return value;
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, string? value, JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        Validate(value);
+        writer.WriteStringValue(value);
+    }
+
+    private static void Validate(string value)
+    {
+        if (!DateTime.TryParseExact(value, IsoDateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out _))
+        {
+            throw new JsonException(
+                $"Cannot convert JSON value '{value}' to an ISO 8601 date. Expected format: {IsoDateFormat}.");
+        }
+    }
+}
+#endif

--- a/StellarDotnetSdk/Crypto/Ed25519.cs
+++ b/StellarDotnetSdk/Crypto/Ed25519.cs
@@ -14,8 +14,10 @@ internal static class Ed25519
         if (seed.Length != SeedLength) throw new ArgumentException($"Seed must be {SeedLength} bytes.", nameof(seed));
 
 #if NETSTANDARD2_1
-        var kp = Sodium.PublicKeyAuth.GenerateKeyPair(seed);
-        return kp.PublicKey;
+        // Clone rather than returning the handle's internal buffer — the returned array must not share
+        // its lifetime with the disposed handle.
+        using var kp = Sodium.PublicKeyAuth.GenerateKeyPair(seed);
+        return (byte[])kp.PublicKey.Clone();
 #else
         using var key = NSec.Cryptography.Key.Import(
             NSec.Cryptography.SignatureAlgorithm.Ed25519,
@@ -36,7 +38,7 @@ internal static class Ed25519
         Throw.IfNull(data, nameof(data));
 
 #if NETSTANDARD2_1
-        var kp = Sodium.PublicKeyAuth.GenerateKeyPair(seed);
+        using var kp = Sodium.PublicKeyAuth.GenerateKeyPair(seed);
         return Sodium.PublicKeyAuth.SignDetached(data, kp.PrivateKey);
 #else
         using var key = NSec.Cryptography.Key.Import(

--- a/StellarDotnetSdk/Crypto/Ed25519Signer.cs
+++ b/StellarDotnetSdk/Crypto/Ed25519Signer.cs
@@ -1,0 +1,53 @@
+using System;
+using StellarDotnetSdk.Compatibility;
+
+namespace StellarDotnetSdk.Crypto;
+
+/// <summary>
+///     A reusable Ed25519 signing handle: the 32-byte seed is expanded/imported once at construction and
+///     reused for every signature, instead of re-deriving the key material on each <c>Sign</c> call.
+/// </summary>
+internal sealed class Ed25519Signer
+{
+#if NETSTANDARD2_1
+    private readonly byte[] _expandedPrivateKey;
+#else
+    private readonly NSec.Cryptography.Key _key;
+#endif
+
+    public Ed25519Signer(byte[] seed)
+    {
+        Throw.IfNull(seed, nameof(seed));
+        if (seed.Length != Ed25519.SeedLength)
+        {
+            throw new ArgumentException($"Seed must be {Ed25519.SeedLength} bytes.", nameof(seed));
+        }
+
+#if NETSTANDARD2_1
+        // Copy the expanded key out of the Sodium handle so the cached key's lifetime is independent of
+        // the handle's — never alias a disposable handle's internal buffer, whatever Dispose does to it.
+        using var kp = Sodium.PublicKeyAuth.GenerateKeyPair(seed);
+        _expandedPrivateKey = (byte[])kp.PrivateKey.Clone();
+#else
+        _key = NSec.Cryptography.Key.Import(
+            NSec.Cryptography.SignatureAlgorithm.Ed25519,
+            seed,
+            NSec.Cryptography.KeyBlobFormat.RawPrivateKey,
+            new NSec.Cryptography.KeyCreationParameters
+            {
+                ExportPolicy = NSec.Cryptography.KeyExportPolicies.AllowPlaintextExport,
+            });
+#endif
+    }
+
+    public byte[] Sign(byte[] data)
+    {
+        Throw.IfNull(data, nameof(data));
+
+#if NETSTANDARD2_1
+        return Sodium.PublicKeyAuth.SignDetached(data, _expandedPrivateKey);
+#else
+        return NSec.Cryptography.SignatureAlgorithm.Ed25519.Sign(_key, data);
+#endif
+    }
+}

--- a/StellarDotnetSdk/Requests/RetryingHttpMessageHandler.cs
+++ b/StellarDotnetSdk/Requests/RetryingHttpMessageHandler.cs
@@ -27,10 +27,24 @@ namespace StellarDotnetSdk.Requests;
 ///         immediately, exactly like a user-initiated cancellation.
 ///     </para>
 /// </summary>
-public class RetryingHttpMessageHandler : DelegatingHandler
+public class RetryingHttpMessageHandler :
+#if NETSTANDARD2_1
+    // Deliberately NOT DelegatingHandler on netstandard2.1: this TFM cannot override the synchronous
+    // Send virtual (it does not exist in netstandard2.1 reference assemblies), and DelegatingHandler's
+    // runtime base Send would forward straight to the inner handler on net5+ hosts — silently bypassing
+    // the entire resilience pipeline. HttpMessageHandler's base Send throws NotSupportedException on
+    // those hosts instead, so a sync caller fails loudly rather than losing retries without a signal.
+    HttpMessageHandler
+#else
+    DelegatingHandler
+#endif
 {
     private static readonly ResiliencePropertyKey<HttpRequestMessage?> RequestKey = new("StellarSdk.HttpRequest");
     private readonly ResiliencePipeline<HttpResponseMessage> _pipeline;
+#if NETSTANDARD2_1
+    private readonly HttpMessageHandler _innerHandler;
+    private readonly HttpMessageInvoker _innerInvoker;
+#endif
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="RetryingHttpMessageHandler" /> class.
@@ -49,8 +63,17 @@ public class RetryingHttpMessageHandler : DelegatingHandler
     ///     subject to this check.
     /// </exception>
     public RetryingHttpMessageHandler(HttpMessageHandler innerHandler, HttpResilienceOptions? options = null)
+#if NETSTANDARD2_1
+    {
+        _innerHandler = innerHandler ?? throw new ArgumentNullException(nameof(innerHandler));
+        // HttpMessageHandler.SendAsync is protected internal, so the inner handler is driven through an
+        // HttpMessageInvoker (the same public wrapper HttpClient itself uses). disposeHandler: false —
+        // Dispose(bool) below owns the inner handler's lifetime, matching DelegatingHandler semantics.
+        _innerInvoker = new HttpMessageInvoker(_innerHandler, false);
+#else
         : base(innerHandler ?? throw new ArgumentNullException(nameof(innerHandler)))
     {
+#endif
         // Snapshot the options. The scalar settings are baked into the pipeline below either way, but the
         // set-typed properties are read by the ShouldHandle/DelayGenerator closures on every request —
         // without a copy, post-construction mutations would half-apply (and HashSet is not thread-safe
@@ -77,7 +100,11 @@ public class RetryingHttpMessageHandler : DelegatingHandler
         try
         {
             return await _pipeline.ExecuteAsync(
+#if NETSTANDARD2_1
+                async ctx => await _innerInvoker.SendAsync(request, ctx.CancellationToken).ConfigureAwait(false),
+#else
                 async ctx => await base.SendAsync(request, ctx.CancellationToken).ConfigureAwait(false),
+#endif
                 context).ConfigureAwait(false);
         }
         finally
@@ -92,9 +119,11 @@ public class RetryingHttpMessageHandler : DelegatingHandler
     ///     Sends an HTTP request through the resilience pipeline synchronously. Mirrors
     ///     <see cref="SendAsync" /> so that <see cref="HttpClient.Send(HttpRequestMessage)" /> receives the
     ///     same retry, circuit-breaker, and timeout behavior instead of silently bypassing the pipeline
-    ///     (the inherited <see cref="DelegatingHandler.Send(HttpRequestMessage, CancellationToken)" />
-    ///     forwards straight to the inner handler). The inner handler chain must itself support synchronous
-    ///     <c>Send</c> (<see cref="SocketsHttpHandler" /> does over HTTP/1.1).
+    ///     (a <c>DelegatingHandler</c>'s inherited sync <c>Send</c> forwards straight to the inner handler).
+    ///     The inner handler chain must itself support synchronous <c>Send</c> (<c>SocketsHttpHandler</c>
+    ///     does over HTTP/1.1). This override exists only on <c>net8.0</c>/<c>net10.0</c>; on the
+    ///     <c>netstandard2.1</c> assembly (which <c>net5</c>–<c>net7</c> apps resolve) synchronous
+    ///     <c>Send</c> throws <see cref="NotSupportedException" /> — see the base-class note above.
     /// </summary>
     /// <param name="request">The HTTP request message to send.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
@@ -113,6 +142,21 @@ public class RetryingHttpMessageHandler : DelegatingHandler
             context.Properties.Set(RequestKey, null);
             ResilienceContextPool.Shared.Return(context);
         }
+    }
+#endif
+
+#if NETSTANDARD2_1
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            // Match DelegatingHandler's contract: disposing the handler disposes its inner handler.
+            _innerInvoker.Dispose();
+            _innerHandler.Dispose();
+        }
+
+        base.Dispose(disposing);
     }
 #endif
 

--- a/StellarDotnetSdk/Sep/Sep0009/KycJsonOptions.cs
+++ b/StellarDotnetSdk/Sep/Sep0009/KycJsonOptions.cs
@@ -7,7 +7,9 @@ namespace StellarDotnetSdk.Sep.Sep0009;
 
 /// <summary>
 ///     JSON serializer options for SEP-0009 KYC field types.
-///     Date fields use ISO 8601 date-only format (yyyy-MM-dd) on frameworks that support date-only types.
+///     Date fields use ISO 8601 date-only format (yyyy-MM-dd) on every target framework: via
+///     <c>DateOnly</c> converters on net8.0/net10.0 and via <c>IsoDateStringJsonConverter</c>
+///     property annotations on netstandard2.1, so invalid date strings are rejected on all targets.
 /// </summary>
 /// <remarks>
 ///     These options use <see cref="JsonNamingPolicy.CamelCase" /> (emitting e.g. <c>birthDate</c>), so they are

--- a/StellarDotnetSdk/Sep/Sep0009/NaturalPersonKycFields.cs
+++ b/StellarDotnetSdk/Sep/Sep0009/NaturalPersonKycFields.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
-#if !NETSTANDARD2_1
 using System.Text.Json.Serialization;
 using StellarDotnetSdk.Converters;
-#endif
 
 namespace StellarDotnetSdk.Sep.Sep0009;
 
@@ -281,6 +279,7 @@ public sealed record NaturalPersonKycFields
     ///     netstandard2.1.
     /// </remarks>
 #if NETSTANDARD2_1
+    [JsonConverter(typeof(IsoDateStringJsonConverter))]
     public string? BirthDate { get; init; }
 #else
     [JsonConverter(typeof(NullableDateOnlyJsonConverter))]
@@ -345,6 +344,7 @@ public sealed record NaturalPersonKycFields
     ///     netstandard2.1.
     /// </remarks>
 #if NETSTANDARD2_1
+    [JsonConverter(typeof(IsoDateStringJsonConverter))]
     public string? IdIssueDate { get; init; }
 #else
     [JsonConverter(typeof(NullableDateOnlyJsonConverter))]
@@ -359,6 +359,7 @@ public sealed record NaturalPersonKycFields
     ///     netstandard2.1.
     /// </remarks>
 #if NETSTANDARD2_1
+    [JsonConverter(typeof(IsoDateStringJsonConverter))]
     public string? IdExpirationDate { get; init; }
 #else
     [JsonConverter(typeof(NullableDateOnlyJsonConverter))]

--- a/StellarDotnetSdk/Sep/Sep0009/OrganizationKycFields.cs
+++ b/StellarDotnetSdk/Sep/Sep0009/OrganizationKycFields.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
-#if !NETSTANDARD2_1
 using System.Text.Json.Serialization;
 using StellarDotnetSdk.Converters;
-#endif
 
 namespace StellarDotnetSdk.Sep.Sep0009;
 
@@ -140,6 +138,7 @@ public sealed record OrganizationKycFields
     ///     netstandard2.1.
     /// </remarks>
 #if NETSTANDARD2_1
+    [JsonConverter(typeof(IsoDateStringJsonConverter))]
     public string? RegistrationDate { get; init; }
 #else
     [JsonConverter(typeof(NullableDateOnlyJsonConverter))]

--- a/StellarDotnetSdk/Util.cs
+++ b/StellarDotnetSdk/Util.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using StellarDotnetSdk.Compatibility;
 
 namespace StellarDotnetSdk;
 
@@ -36,8 +37,19 @@ public static class Util
     /// </summary>
     /// <param name="s">The hexadecimal string to convert.</param>
     /// <returns>The decoded byte array.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="s" /> is null.</exception>
+    /// <exception cref="FormatException">
+    ///     Thrown when <paramref name="s" /> has an odd length or contains a non-hexadecimal character —
+    ///     the same exception type <see cref="Convert.FromHexString(string)" /> throws for such input.
+    /// </exception>
     public static byte[] HexToBytes(string s)
     {
+        Throw.IfNull(s, nameof(s));
+        if (s.Length % 2 != 0)
+        {
+            throw new FormatException("The input is not a valid hex string as its length is not a multiple of 2.");
+        }
+
         var len = s.Length;
         var data = new byte[len / 2];
         for (var i = 0; i < len; i += 2)


### PR DESCRIPTION
Follow-up to #195, addressing the post-merge review findings ([review](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195#pullrequestreview-4617941473)). Every fix below was verified by a runtime probe on the built assemblies of all three TFMs; each behavioral claim has a test that runs on every leg where it applies.

One finding is deliberately **not** in this PR: the net8.0/netstandard2.1 duplicate-property/nullability protections ([comment](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195#discussion_r3513425655)) reverse a dependency decision made during the #195 review, so they ship separately for visibility — see #201.

## Review-finding closure map

| Review comment | Resolution |
|---|---|
| [KeyPair ctor lost length validation](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195#discussion_r3513425651) | **Fixed** — all three ctor args validated as exactly 32 bytes at construction; `FromPublicKey(new byte[16])` throws again instead of minting a malformed account ID |
| [`seed ?? privateKey` conflation](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195#discussion_r3513425658) | **Fixed** — `privateKey`/`seed` tracked separately; a seed-only KeyPair reports `CanSign() == false` and `SecretSeed` never echoes material passed as `privateKey` |
| [ns21 KYC dates unvalidated in JSON](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195#discussion_r3513425664) | **Fixed** — new `IsoDateStringJsonConverter` rejects anything but `yyyy-MM-dd` on read *and* write on netstandard2.1; rejection-parity tests run on the ns21 leg |
| [README Unity 2022.3 claim vs `required` members](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195#discussion_r3513425670) | **Documented** — README now carries a compiler note: the failure is compiler-generation (pre-Roslyn-4.4 rejects the poison-pill ctor attribute), not C# language version; Unity 6 works, Unity 2022.3 needs an upgraded Roslyn |
| [`HexToBytes` exception regression](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195#discussion_r3513425675) | **Fixed** — `ArgumentNullException` on null, `FormatException` on odd length (was NRE / `IndexOutOfRangeException`), matching the released `Convert.FromHexString` contract |
| [Sync `Send` silently bypasses Polly on the ns21 asset](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195#discussion_r3513425679) | **Fixed (fail-loud)** — on netstandard2.1 the handler derives from `HttpMessageHandler` instead of `DelegatingHandler`, so sync `Send` on a net5+ host throws `NotSupportedException` rather than skipping retries; test asserts the request never reaches the inner handler |
| [`Throw.IfNullOrEmpty` message divergence](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195#discussion_r3513425687) | **Fixed** — polyfill emits the BCL text, pinned by a parity test on every leg |
| [Cancellation shim throws base `OperationCanceledException`](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195#discussion_r3513425694) | **Fixed** — shim surfaces `TaskCanceledException` with the token attached (via `Task.FromCanceled`), matching the net6+ overload; both pre-canceled and mid-read paths tested |
| [`FromSecretSeed(byte[])` exception contract](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195#discussion_r3513425699) | **Fixed** — construct-time `ArgumentException`, documented in XML docs and CHANGELOG as the deliberate contract |
| [XDR generator template/snapshot desync](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195#discussion_r3513425705) | **Fixed** — snapshots re-blessed; the snapshot test now normalizes line endings (passes on Windows and Linux); new `xdr_generator_tests` CI job runs the ruby suite so desync can't land silently again |
| [Per-signature key re-import (~2.4x overhead)](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195#discussion_r3513425712) | **Fixed** — new `Ed25519Signer` caches the expanded/imported key per `KeyPair` (lazy, CAS-published). Probe: 94 vs 315 µs/op (NSec/net10) and 62 vs 251 µs/op (Sodium/ns21) against the re-derive shape |
| [`Sodium.KeyPair` never disposed](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195#discussion_r3513425717) | **Fixed** — all Sodium handles disposed; cached key material is cloned first so its lifetime is independent of the handle |
| [`ReadExactlyCompat` message divergence](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195#discussion_r3513425724) | **Fixed** — BCL-exact `EndOfStreamException` message, pinned by a test on every leg |
| [integration_tests.yml SDK pin](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195#pullrequestreview-4617941473) | **Hardened** — the workflow was green (runner image preinstalls .NET 10), but only by accident; it now installs `8.0.x` + `10.0.x` explicitly |

## Verification

- Full unit suites green on this branch standalone: net10.0 **1967**, net8.0 **1952**, netstandard2.1-via-net8-host **1958** passed, 0 failures; ruby snapshot suite 76 assertions, 0 failures.
- An independent fresh-context review of this diff (build + runtime probes, including a 200k-concurrent-sign race test on the cached signer and a Sodium dispose-zeroing probe) found no blocker/major/minor issues.
