### PR TITLE
chore!: restore serializer-level JSON protections and extend converter-level hardening to all TFMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,11 @@ All notable changes to this project are documented here. The format is based on
   `rel_before`/`abs_before_epoch` is rejected (Stellar time bounds are unsigned), and a payload that
   supplies both `abs_before` and `abs_before_epoch` with disagreeing instants is rejected rather than
   silently preferring the epoch — a spoofed epoch can no longer shift a claim deadline while the
-  human-readable `abs_before` string still looks correct.
+  human-readable `abs_before` string still looks correct. `PredicateBeforeAbsoluteTime.DateTime` now
+  parses `abs_before` with the same rules as that consistency check (invariant culture; a value without
+  an offset designator is interpreted as UTC) instead of the machine's current culture and local time
+  zone, so an epoch-less payload resolves to the same deadline instant on every machine. Horizon always
+  emits `abs_before` with an explicit offset, so values from Horizon are unaffected.
 - The `Asset` and `Reserve` converters now skip unrecognized properties with object/array values
   whole. Previously the reader descended into such values and treated their nested keys as top-level
   properties. With the new duplicate-property guard in place that surfaced as a misleading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,9 +64,10 @@ All notable changes to this project are documented here. The format is based on
   (duplicate keys, or explicit `null` for a non-nullable member) are now rejected, and consumers on
   `net8.0`/`netstandard2.1` inherit a transitive `System.Text.Json >= 10.0.6` floor plus its own
   dependencies (`System.Text.Encodings.Web` and `System.IO.Pipelines` 10.0.6 on both TFMs; on
-  `netstandard2.1` also `Microsoft.Bcl.AsyncInterfaces` 10.0.6 — with `System.IO.Pipelines` net-new
-  relative to the previous `System.Text.Json` 8.0.5 reference, one more DLL for consumers who vendor
-  dependencies by hand, e.g. Unity)
+  `netstandard2.1` also `Microsoft.Bcl.AsyncInterfaces` 10.0.6). `netstandard2.1` is the only target
+  that previously pinned `System.Text.Json` 8.0.5, and relative to that 8.0.5 closure `System.IO.Pipelines`
+  is net-new — one more DLL for consumers who vendor dependencies by hand, e.g. Unity. (`net8.0` never
+  referenced 8.0.5: it resolved the built-in framework `System.Text.Json` before this package reference.)
   ([#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195) follow-up).
 - `KeyPair.Verify` no longer swallows every exception. Malformed or attacker-supplied signatures still
   return `false` (`ArgumentException`, `FormatException`, and `CryptographicException` are caught), but
@@ -86,11 +87,15 @@ All notable changes to this project are documented here. The format is based on
   object mapper only, so fields read manually by a converter were last-wins: a malformed or adversarial
   Horizon response could silently override a financial field by repeating its key. Hardened converters:
   `AssetAmount`, `Reserve`, `LiquidityPoolClaimableAssetAmount`, `Asset` (asset-code/issuer
-  substitution), `Predicate` (claimable-balance time locks, checked at every nesting level), and the
-  HATEOAS `Link` converter (pagination `href`). The two remaining hand-parsing converters — the
-  polymorphic `OperationResponse`/`EffectResponse` converters — read only the `type_i` discriminator by
-  hand and re-deserialize the payload through the object mapper, so duplicates on their fields are
-  rejected by the serializer-level guard without a converter-level one.
+  substitution), `Predicate` (claimable-balance time locks, checked at every nesting level), the
+  HATEOAS `Link` converter (pagination `href`), and the SEP-45 `ChallengeForContractsResponse` converter
+  (the adversarial `authorization_entries` blob the client signs — it already rejected duplicates inline
+  and now shares the `JsonDuplicatePropertyGuard` helper). The polymorphic `OperationResponse`/`EffectResponse`
+  converters read the `type_i` discriminator by hand and re-deserialize the payload through the object
+  mapper; the mapper rejects duplicates of the mapped payload fields, but because `type_i` is a read-only
+  property the mapper never binds a duplicated discriminator would otherwise slip through, so these two
+  converters now apply the same guard to the whole object and reject any duplicate — discriminator
+  included — before dispatching.
 
 ### Removed
 
@@ -103,13 +108,28 @@ All notable changes to this project are documented here. The format is based on
 - `PredicateJsonConverter` no longer leaks `FormatException`/`OverflowException` for malformed
   `rel_before`/`abs_before_epoch` values — every malformed predicate now throws `JsonException`, the
   SDK's documented deserialization failure mode. It also rejects `and`/`or` predicate arrays that do
-  not contain exactly 2 elements (Stellar's `ClaimPredicate` AND/OR are strictly binary; extra
-  elements were previously dropped silently) and validates the arity before deserializing any element,
-  so an oversized array is no longer fully materialized.
+  not contain exactly 2 elements (stellar-core validates `ClaimPredicate` AND/OR to exactly 2 children
+  at ledger close, so Horizon never emits any other arity; extra elements were previously dropped
+  silently) and validates the arity before deserializing any element, so an oversized array is no
+  longer fully materialized. Time-bound values are now also range- and consistency-checked: a negative
+  `rel_before`/`abs_before_epoch` is rejected (Stellar time bounds are unsigned), and a payload that
+  supplies both `abs_before` and `abs_before_epoch` with disagreeing instants is rejected rather than
+  silently preferring the epoch — a spoofed epoch can no longer shift a claim deadline while the
+  human-readable `abs_before` string still looks correct.
 - The `Asset` and `Reserve` converters now skip unrecognized properties with object/array values
   whole. Previously the reader descended into such values and treated their nested keys as top-level
-  properties, which could reject valid payloads with a misleading duplicate-property error (the
-  malformed-payload path always failed closed — no silent corruption was possible).
+  properties. With the new duplicate-property guard in place that surfaced as a misleading
+  duplicate-property rejection of an otherwise-valid payload; in releases without that guard (≤ 15.1.0)
+  a nested key reusing a top-level name — e.g. `amount` inside a `_links` object — could instead
+  silently overwrite the top-level financial field. Skipping unrecognized values whole closes both.
+- **Breaking:** the `Asset`, `AssetAmount`, `Reserve`, and `LiquidityPoolClaimableAssetAmount` converters
+  now throw `JsonException` — the documented System.Text.Json deserialization failure mode — for missing,
+  `null`, empty, or malformed `asset`/`amount`/`asset_code`/`asset_issuer` values, where they previously
+  leaked `ArgumentException` (or `AssetCodeLengthInvalidException` for an out-of-range asset code). A
+  consumer can now catch every malformed-response failure from `JsonSerializer.Deserialize` with a single
+  `catch (JsonException)`; code that specifically caught `ArgumentException` from these converters must
+  catch `JsonException` instead. (The `Asset.Create`/`Asset.CreateNonNativeAsset` factory methods, when
+  called directly, still throw `ArgumentException`/`AssetCodeLengthInvalidException`.)
 - `Util.Hash` no longer leaks a `SHA256` instance on every call: it uses the static
   `SHA256.HashData` on `net8.0`/`net10.0` and a properly disposed instance on `netstandard2.1`
   ([#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,12 +51,13 @@ All notable changes to this project are documented here. The format is based on
 - The `SorobanCredentials`, `SorobanSourceAccountCredentials`, and `SorobanAddressCredentials` classes
   moved from `InvokeHostFunctionOperation.cs` to a new `SorobanCredentials.cs` file. They remain in the
   `StellarDotnetSdk.Operations` namespace, so `using`/fully-qualified references are unaffected.
-- **Breaking (behavioral, `net8.0`):** the SDK no longer references the standalone `System.Text.Json`
-  10.0.6 package and uses each target framework's built-in System.Text.Json instead. As a result,
-  `AllowDuplicateProperties = false` and `RespectNullableAnnotations = true` on
-  `JsonOptions.DefaultOptions` now apply on `net10.0` only; on `net8.0` and `netstandard2.1`,
-  deserialization follows the STJ 8 defaults — the last duplicate JSON property wins and nullability
-  annotations are not enforced ([#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195)).
+- The SDK references the standalone `System.Text.Json` 10.0.6 package on `net8.0` and
+  `netstandard2.1` (`net10.0` uses the built-in STJ 10), so `AllowDuplicateProperties = false` and
+  `RespectNullableAnnotations = true` on `JsonOptions.DefaultOptions` / `KycJsonOptions.Default`
+  apply on **every** target framework: a response carrying a duplicate JSON property is rejected
+  instead of last-write-wins, and nullability annotations are enforced uniformly. Consumers on
+  `net8.0`/`netstandard2.1` inherit a transitive `System.Text.Json >= 10.0.6` dependency floor
+  ([#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195) follow-up).
 - `KeyPair.Verify` no longer swallows every exception. Malformed or attacker-supplied signatures still
   return `false` (`ArgumentException`, `FormatException`, and `CryptographicException` are caught), but
   environmental failures — e.g. a missing native libsodium — now propagate instead of being misreported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,11 +54,19 @@ All notable changes to this project are documented here. The format is based on
 - **Breaking:** the SDK references the standalone `System.Text.Json` 10.0.6 package on `net8.0` and
   `netstandard2.1` (`net10.0` uses the built-in STJ 10), so `AllowDuplicateProperties = false` and
   `RespectNullableAnnotations = true` on `JsonOptions.DefaultOptions` / `KycJsonOptions.Default`
-  apply on **every** target framework: a response carrying a duplicate JSON property is rejected
-  instead of last-write-wins, and nullability annotations are enforced uniformly. This is breaking
-  in two ways — payloads that previously deserialized on `net8.0`/`netstandard2.1` (duplicate keys,
-  or `null` for a non-nullable member) are now rejected, and consumers on `net8.0`/`netstandard2.1`
-  inherit a transitive `System.Text.Json >= 10.0.6` dependency floor
+  apply on **every** target framework: a duplicate JSON property on a POCO-mapped field now throws
+  `JsonException` instead of last-write-wins (fields parsed by the SDK's hand-written converters,
+  e.g. `Reserve`/`Asset`/`AssetAmount`, are outside this option's reach but are now guarded
+  separately — see the Security entry below), and explicit `null` for a non-nullable member also
+  throws `JsonException`. For `KycJsonOptions.Default`, duplicate-property rejection is new on every
+  TFM including `net10.0` (it previously enforced only nullability, and only on `net10.0`). This is
+  breaking in two ways — payloads that previously deserialized on `net8.0`/`netstandard2.1`
+  (duplicate keys, or explicit `null` for a non-nullable member) are now rejected, and consumers on
+  `net8.0`/`netstandard2.1` inherit a transitive `System.Text.Json >= 10.0.6` floor plus its own
+  dependencies (`System.Text.Encodings.Web` and `System.IO.Pipelines` 10.0.6 on both TFMs; on
+  `netstandard2.1` also `Microsoft.Bcl.AsyncInterfaces` 10.0.6 — with `System.IO.Pipelines` net-new
+  relative to the previous `System.Text.Json` 8.0.5 reference, one more DLL for consumers who vendor
+  dependencies by hand, e.g. Unity)
   ([#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195) follow-up).
 - `KeyPair.Verify` no longer swallows every exception. Malformed or attacker-supplied signatures still
   return `false` (`ArgumentException`, `FormatException`, and `CryptographicException` are caught), but
@@ -69,6 +77,21 @@ All notable changes to this project are documented here. The format is based on
   path only on `net8.0`/`net10.0` — use `SendAsync` on `netstandard2.1`
   ([#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195)).
 
+### Security
+
+- **Breaking:** converters that hand-parse JSON now reject objects that define the same property more
+  than once (throwing `JsonException`, matched case-insensitively), on every target framework — payloads
+  with duplicate keys that previously deserialized last-wins are now rejected. The serializer-level
+  `AllowDuplicateProperties = false` guard on `JsonOptions.DefaultOptions` is enforced by the built-in
+  object mapper only, so fields read manually by a converter were last-wins: a malformed or adversarial
+  Horizon response could silently override a financial field by repeating its key. Hardened converters:
+  `AssetAmount`, `Reserve`, `LiquidityPoolClaimableAssetAmount`, `Asset` (asset-code/issuer
+  substitution), `Predicate` (claimable-balance time locks, checked at every nesting level), and the
+  HATEOAS `Link` converter (pagination `href`). The two remaining hand-parsing converters — the
+  polymorphic `OperationResponse`/`EffectResponse` converters — read only the `type_i` discriminator by
+  hand and re-deserialize the payload through the object mapper, so duplicates on their fields are
+  rejected by the serializer-level guard without a converter-level one.
+
 ### Removed
 
 - **Breaking:** `SorobanSourceAccountCredentials.ToSorobanCredentialsXdr()` and
@@ -77,6 +100,16 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- `PredicateJsonConverter` no longer leaks `FormatException`/`OverflowException` for malformed
+  `rel_before`/`abs_before_epoch` values — every malformed predicate now throws `JsonException`, the
+  SDK's documented deserialization failure mode. It also rejects `and`/`or` predicate arrays that do
+  not contain exactly 2 elements (Stellar's `ClaimPredicate` AND/OR are strictly binary; extra
+  elements were previously dropped silently) and validates the arity before deserializing any element,
+  so an oversized array is no longer fully materialized.
+- The `Asset` and `Reserve` converters now skip unrecognized properties with object/array values
+  whole. Previously the reader descended into such values and treated their nested keys as top-level
+  properties, which could reject valid payloads with a misleading duplicate-property error (the
+  malformed-payload path always failed closed — no silent corruption was possible).
 - `Util.Hash` no longer leaks a `SHA256` instance on every call: it uses the static
   `SHA256.HashData` on `net8.0`/`net10.0` and a properly disposed instance on `netstandard2.1`
   ([#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,12 +51,14 @@ All notable changes to this project are documented here. The format is based on
 - The `SorobanCredentials`, `SorobanSourceAccountCredentials`, and `SorobanAddressCredentials` classes
   moved from `InvokeHostFunctionOperation.cs` to a new `SorobanCredentials.cs` file. They remain in the
   `StellarDotnetSdk.Operations` namespace, so `using`/fully-qualified references are unaffected.
-- The SDK references the standalone `System.Text.Json` 10.0.6 package on `net8.0` and
+- **Breaking:** the SDK references the standalone `System.Text.Json` 10.0.6 package on `net8.0` and
   `netstandard2.1` (`net10.0` uses the built-in STJ 10), so `AllowDuplicateProperties = false` and
   `RespectNullableAnnotations = true` on `JsonOptions.DefaultOptions` / `KycJsonOptions.Default`
   apply on **every** target framework: a response carrying a duplicate JSON property is rejected
-  instead of last-write-wins, and nullability annotations are enforced uniformly. Consumers on
-  `net8.0`/`netstandard2.1` inherit a transitive `System.Text.Json >= 10.0.6` dependency floor
+  instead of last-write-wins, and nullability annotations are enforced uniformly. This is breaking
+  in two ways — payloads that previously deserialized on `net8.0`/`netstandard2.1` (duplicate keys,
+  or `null` for a non-nullable member) are now rejected, and consumers on `net8.0`/`netstandard2.1`
+  inherit a transitive `System.Text.Json >= 10.0.6` dependency floor
   ([#195](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195) follow-up).
 - `KeyPair.Verify` no longer swallows every exception. Malformed or attacker-supplied signatures still
   return `false` (`ArgumentException`, `FormatException`, and `CryptographicException` are caught), but

--- a/StellarDotnetSdk.NetStandard21.Tests/SystemTextJsonNetStandard20AssetTest.cs
+++ b/StellarDotnetSdk.NetStandard21.Tests/SystemTextJsonNetStandard20AssetTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
 using System.Text.Json;
+using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace StellarDotnetSdk.Tests;
@@ -25,7 +26,11 @@ public class SystemTextJsonNetStandard20AssetTest
 {
     private const string DuplicatePropertyJson = """{"Value":1,"Value":2}""";
 
-    private static readonly Lazy<NetStandard20SystemTextJson> Stj = new(NetStandard20SystemTextJson.Load);
+    // PublicationOnly so a transient load failure (e.g. project.assets.json not yet restored) is not
+    // cached forever: the default Lazy mode caches the first exception and re-throws it for every later
+    // access, which would mask the real first failure behind identical repeats across the test methods.
+    private static readonly Lazy<NetStandard20SystemTextJson> Stj =
+        new(NetStandard20SystemTextJson.Load, LazyThreadSafetyMode.PublicationOnly);
 
     /// <summary>
     ///     The netstandard2.1 restore must keep resolving a System.Text.Json version whose
@@ -227,7 +232,16 @@ public class SystemTextJsonNetStandard20AssetTest
                     {
                         stjPath = fullPath;
                         var prerelease = version.IndexOfAny(new[] { '-', '+' });
-                        stjVersion = Version.Parse(prerelease < 0 ? version : version[..prerelease]);
+                        var core = prerelease < 0 ? version : version[..prerelease];
+                        if (!Version.TryParse(core, out var parsedVersion))
+                        {
+                            throw new InvalidOperationException(
+                                $"Could not parse the resolved System.Text.Json version '{version}' " +
+                                $"(core '{core}') from {assetsFile}. Update this probe if the version " +
+                                "string format changed.");
+                        }
+
+                        stjVersion = parsedVersion;
                     }
                 }
             }

--- a/StellarDotnetSdk.NetStandard21.Tests/SystemTextJsonNetStandard20AssetTest.cs
+++ b/StellarDotnetSdk.NetStandard21.Tests/SystemTextJsonNetStandard20AssetTest.cs
@@ -1,0 +1,269 @@
+#if TEST_SDK_NETSTANDARD21
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Text.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace StellarDotnetSdk.Tests;
+
+/// <summary>
+///     Exercises the <c>lib/netstandard2.0</c> System.Text.Json asset that real netstandard2.1
+///     consumers (Unity, Tizen, Mono) load at runtime. This test project runs the netstandard2.1
+///     SDK build on the net8.0 CLR, which resolves the package's <c>lib/net8.0</c> asset instead,
+///     so without this probe the asset that actually ships to those consumers is never executed
+///     in CI. The asset and its package dependency closure are resolved from the SDK's
+///     <c>project.assets.json</c> restore output, loaded from the NuGet cache into an isolated
+///     <see cref="AssemblyLoadContext" />, and driven via reflection because its types are
+///     distinct from the host's own System.Text.Json.
+/// </summary>
+[TestClass]
+public class SystemTextJsonNetStandard20AssetTest
+{
+    private const string DuplicatePropertyJson = """{"Value":1,"Value":2}""";
+
+    private static readonly Lazy<NetStandard20SystemTextJson> Stj = new(NetStandard20SystemTextJson.Load);
+
+    /// <summary>
+    ///     The netstandard2.1 restore must keep resolving a System.Text.Json version whose
+    ///     <c>lib/netstandard2.0</c> asset carries the serializer-level
+    ///     <c>AllowDuplicateProperties</c> guard, i.e. the 10.x floor introduced for the
+    ///     netstandard2.1 target. This fails on any downgrade (8.x has no such option).
+    /// </summary>
+    [TestMethod]
+    public void NetStandard21Restore_ResolvesNetStandard20Asset_WithSerializerLevelDuplicateGuard()
+    {
+        var stj = Stj.Value;
+
+        StringAssert.Contains(stj.AssetPath.Replace('\\', '/'), "lib/netstandard2.0/System.Text.Json.dll");
+        Assert.AreNotSame(typeof(JsonSerializerOptions).Assembly, stj.Assembly,
+            "The probe must exercise the netstandard2.0 asset, not the lib/net8.0 asset the test host itself uses.");
+        Assert.IsTrue(stj.PackageVersion.Major >= 10,
+            $"netstandard2.1 resolved System.Text.Json {stj.PackageVersion}, but the serializer-level " +
+            "AllowDuplicateProperties guard only exists from 10.x on. Unity/Tizen/Mono consumers of the " +
+            "netstandard2.1 package would silently lose duplicate-property rejection.");
+        Assert.IsNotNull(stj.AllowDuplicateProperties,
+            "JsonSerializerOptions.AllowDuplicateProperties is missing from the netstandard2.0 asset.");
+    }
+
+    /// <summary>
+    ///     With <c>AllowDuplicateProperties = false</c> the netstandard2.0 asset itself must reject
+    ///     a duplicated property instead of letting the last value win. The serializer is invoked
+    ///     via reflection, so the JsonException surfaces wrapped in a TargetInvocationException.
+    /// </summary>
+    [TestMethod]
+    public void NetStandard20Asset_DuplicateProperty_ThrowsJsonException()
+    {
+        var ex = Assert.ThrowsException<TargetInvocationException>(() =>
+            Stj.Value.Deserialize(DuplicatePropertyJson, typeof(Probe), allowDuplicateProperties: false));
+
+        Assert.IsNotNull(ex.InnerException);
+        Assert.AreEqual("System.Text.Json.JsonException", ex.InnerException!.GetType().FullName);
+        Assert.AreSame(Stj.Value.Assembly, ex.InnerException.GetType().Assembly,
+            "The rejection must be raised by the isolated netstandard2.0 asset itself.");
+    }
+
+    /// <summary>
+    ///     Control case proving the probe harness is sensitive: the same payload deserializes
+    ///     without error when duplicates are explicitly allowed, so a throw in the strict test
+    ///     can only come from the duplicate-property guard.
+    /// </summary>
+    [TestMethod]
+    public void NetStandard20Asset_DuplicatePropertyAllowed_LastValueWins()
+    {
+        var result = Stj.Value.Deserialize(DuplicatePropertyJson, typeof(Probe), allowDuplicateProperties: true);
+
+        var probe = (Probe)result!;
+        Assert.AreEqual(2, probe.Value);
+    }
+
+    /// <summary>
+    ///     Deserialization target; public so the isolated serializer can bind to it across
+    ///     load-context boundaries.
+    /// </summary>
+    public sealed class Probe
+    {
+        public int Value { get; set; }
+    }
+
+    /// <summary>
+    ///     The netstandard2.0 System.Text.Json asset plus its resolved package closure, loaded
+    ///     into an isolated <see cref="AssemblyLoadContext" />.
+    /// </summary>
+    private sealed class NetStandard20SystemTextJson
+    {
+        private readonly MethodInfo _deserialize;
+        private readonly Type _optionsType;
+
+        private NetStandard20SystemTextJson(Assembly assembly, string assetPath, Version packageVersion)
+        {
+            Assembly = assembly;
+            AssetPath = assetPath;
+            PackageVersion = packageVersion;
+            _optionsType = assembly.GetType("System.Text.Json.JsonSerializerOptions", throwOnError: true)!;
+            AllowDuplicateProperties = _optionsType.GetProperty("AllowDuplicateProperties");
+            _deserialize = assembly.GetType("System.Text.Json.JsonSerializer", throwOnError: true)!
+                               .GetMethod("Deserialize", new[] { typeof(string), typeof(Type), _optionsType })
+                           ?? throw new MissingMethodException(
+                               "System.Text.Json.JsonSerializer",
+                               "Deserialize(string, Type, JsonSerializerOptions)");
+        }
+
+        public Assembly Assembly { get; }
+        public string AssetPath { get; }
+        public Version PackageVersion { get; }
+        public PropertyInfo? AllowDuplicateProperties { get; }
+
+        public static NetStandard20SystemTextJson Load()
+        {
+            var assetsFile = FindSdkAssetsFile();
+            var (assemblyPaths, stjPath, stjVersion) = ReadNetStandard21RuntimeClosure(assetsFile);
+            var context = new PackageAssemblyLoadContext(assemblyPaths);
+            var assembly = context.LoadFromAssemblyPath(stjPath);
+            return new NetStandard20SystemTextJson(assembly, stjPath, stjVersion);
+        }
+
+        public object? Deserialize(string json, Type returnType, bool allowDuplicateProperties)
+        {
+            if (AllowDuplicateProperties == null)
+            {
+                throw new InvalidOperationException(
+                    $"System.Text.Json {PackageVersion} (netstandard2.0 asset) has no " +
+                    "JsonSerializerOptions.AllowDuplicateProperties; the serializer-level duplicate-property " +
+                    "guard requires System.Text.Json 10.x or later on the netstandard2.1 target.");
+            }
+
+            var options = Activator.CreateInstance(_optionsType);
+            AllowDuplicateProperties.SetValue(options, allowDuplicateProperties);
+            return _deserialize.Invoke(null, new[] { json, (object)returnType, options });
+        }
+
+        private static string FindSdkAssetsFile()
+        {
+            for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory != null; directory = directory.Parent)
+            {
+                var candidate = Path.Combine(directory.FullName, "StellarDotnetSdk", "obj", "project.assets.json");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            throw new FileNotFoundException(
+                "Could not locate StellarDotnetSdk/obj/project.assets.json above the test output directory. " +
+                "The probe needs the SDK's restore output to know which packages netstandard2.1 resolved; " +
+                "run 'dotnet restore' on the solution first.");
+        }
+
+        /// <summary>
+        ///     Reads the netstandard2.1 target of the SDK's assets file and maps every resolved
+        ///     package runtime assembly to its NuGet-cache path — the exact closure a
+        ///     netstandard2.1 package consumer restores.
+        /// </summary>
+        private static (Dictionary<string, string> AssemblyPaths, string StjPath, Version StjVersion)
+            ReadNetStandard21RuntimeClosure(string assetsFile)
+        {
+            using var assets = JsonDocument.Parse(File.ReadAllText(assetsFile));
+
+            var packageFolders = assets.RootElement.GetProperty("packageFolders")
+                .EnumerateObject()
+                .Select(folder => folder.Name)
+                .ToList();
+
+            var target = assets.RootElement.GetProperty("targets")
+                .EnumerateObject()
+                .FirstOrDefault(candidate => candidate.Name == "netstandard2.1"
+                                             || candidate.Name.StartsWith(".NETStandard,Version=v2.1",
+                                                 StringComparison.Ordinal));
+            if (target.Value.ValueKind != JsonValueKind.Object)
+            {
+                throw new InvalidOperationException(
+                    $"No netstandard2.1 target found in {assetsFile}; was the SDK's netstandard2.1 " +
+                    "TargetFramework removed?");
+            }
+
+            var assemblyPaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            string? stjPath = null;
+            Version? stjVersion = null;
+
+            foreach (var library in target.Value.EnumerateObject())
+            {
+                if (!library.Value.TryGetProperty("type", out var type) || type.GetString() != "package"
+                    || !library.Value.TryGetProperty("runtime", out var runtime))
+                {
+                    continue;
+                }
+
+                var separator = library.Name.IndexOf('/');
+                var id = library.Name[..separator];
+                var version = library.Name[(separator + 1)..];
+
+                foreach (var asset in runtime.EnumerateObject())
+                {
+                    // Skips the "_._" placeholders packages use for empty runtime groups.
+                    if (!asset.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    // The NuGet cache lowercases package id and version directory names.
+                    var relativePath = Path.Combine(
+                        id.ToLowerInvariant(),
+                        version.ToLowerInvariant(),
+                        asset.Name.Replace('/', Path.DirectorySeparatorChar));
+                    var fullPath = packageFolders
+                                       .Select(folder => Path.Combine(folder, relativePath))
+                                       .FirstOrDefault(File.Exists)
+                                   ?? throw new FileNotFoundException(
+                                       $"Package asset {relativePath} was not found in any NuGet package folder " +
+                                       $"({string.Join(", ", packageFolders)}); run 'dotnet restore' first.");
+
+                    assemblyPaths[Path.GetFileNameWithoutExtension(asset.Name)] = fullPath;
+
+                    if (id.Equals("System.Text.Json", StringComparison.OrdinalIgnoreCase))
+                    {
+                        stjPath = fullPath;
+                        var prerelease = version.IndexOfAny(new[] { '-', '+' });
+                        stjVersion = Version.Parse(prerelease < 0 ? version : version[..prerelease]);
+                    }
+                }
+            }
+
+            if (stjPath == null || stjVersion == null)
+            {
+                throw new InvalidOperationException(
+                    "The netstandard2.1 target no longer resolves a System.Text.Json package runtime asset; " +
+                    "update or remove this probe.");
+            }
+
+            return (assemblyPaths, stjPath, stjVersion);
+        }
+    }
+
+    /// <summary>
+    ///     Resolves the recorded package closure inside the isolated context and defers everything
+    ///     else (System.Private.CoreLib, the netstandard facade, ...) to the default context — the
+    ///     same split a Unity/Mono runtime applies between package and framework assemblies.
+    /// </summary>
+    private sealed class PackageAssemblyLoadContext : AssemblyLoadContext
+    {
+        private readonly IReadOnlyDictionary<string, string> _assemblyPaths;
+
+        public PackageAssemblyLoadContext(IReadOnlyDictionary<string, string> assemblyPaths)
+            : base(nameof(SystemTextJsonNetStandard20AssetTest))
+        {
+            _assemblyPaths = assemblyPaths;
+        }
+
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            return assemblyName.Name is { } name && _assemblyPaths.TryGetValue(name, out var path)
+                ? LoadFromAssemblyPath(path)
+                : null;
+        }
+    }
+}
+#endif

--- a/StellarDotnetSdk.Tests/Converters/AssetAmountJsonConverterTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/AssetAmountJsonConverterTest.cs
@@ -121,11 +121,11 @@ public class AssetAmountJsonConverterTest
     }
 
     /// <summary>
-    ///     Verifies that deserializing JSON with missing asset property throws ArgumentException.
+    ///     Verifies that deserializing JSON with missing asset property throws JsonException.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public void Deserialize_WithMissingAsset_ThrowsArgumentException()
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithMissingAsset_ThrowsJsonException()
     {
         // Arrange
         var json = @"{""amount"":""100""}";
@@ -135,11 +135,11 @@ public class AssetAmountJsonConverterTest
     }
 
     /// <summary>
-    ///     Verifies that deserializing JSON with missing amount property throws ArgumentException.
+    ///     Verifies that deserializing JSON with missing amount property throws JsonException.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public void Deserialize_WithMissingAmount_ThrowsArgumentException()
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithMissingAmount_ThrowsJsonException()
     {
         // Arrange
         var json = @"{""asset"":""native""}";
@@ -149,11 +149,11 @@ public class AssetAmountJsonConverterTest
     }
 
     /// <summary>
-    ///     Verifies that deserializing JSON with null asset property throws ArgumentException.
+    ///     Verifies that deserializing JSON with null asset property throws JsonException.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public void Deserialize_WithNullAsset_ThrowsArgumentException()
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithNullAsset_ThrowsJsonException()
     {
         // Arrange
         var json = @"{""asset"":null,""amount"":""100""}";
@@ -163,11 +163,11 @@ public class AssetAmountJsonConverterTest
     }
 
     /// <summary>
-    ///     Verifies that deserializing JSON with null amount property throws ArgumentException.
+    ///     Verifies that deserializing JSON with null amount property throws JsonException.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public void Deserialize_WithNullAmount_ThrowsArgumentException()
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithNullAmount_ThrowsJsonException()
     {
         // Arrange
         var json = @"{""asset"":""native"",""amount"":null}";
@@ -262,11 +262,11 @@ public class AssetAmountJsonConverterTest
     }
 
     /// <summary>
-    ///     Verifies that deserializing JSON with empty asset property throws ArgumentException.
+    ///     Verifies that deserializing JSON with empty asset property throws JsonException.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public void Deserialize_WithEmptyAsset_ThrowsArgumentException()
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithEmptyAsset_ThrowsJsonException()
     {
         // Arrange
         var json = @"{""asset"":"""",""amount"":""100""}";

--- a/StellarDotnetSdk.Tests/Converters/AssetAmountJsonConverterTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/AssetAmountJsonConverterTest.cs
@@ -274,4 +274,18 @@ public class AssetAmountJsonConverterTest
         // Act
         JsonSerializer.Deserialize<AssetAmount>(json, _options);
     }
+
+    /// <summary>
+    ///     Verifies that deserializing JSON with empty amount property throws JsonException.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithEmptyAmount_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""asset"":""native"",""amount"":""""}";
+
+        // Act
+        JsonSerializer.Deserialize<AssetAmount>(json, _options);
+    }
 }

--- a/StellarDotnetSdk.Tests/Converters/AssetJsonConverterTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/AssetJsonConverterTest.cs
@@ -190,6 +190,21 @@ public class AssetJsonConverterTest
     }
 
     /// <summary>
+    ///     Tests that deserialization throws JsonException when credit asset has an empty asset_issuer.
+    ///     An empty issuer would otherwise produce an Asset whose canonical name ends in ":".
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithNonNativeEmptyIssuer_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""asset_type"":""credit_alphanum4"",""asset_code"":""USD"",""asset_issuer"":""""}";
+
+        // Act & Assert
+        JsonSerializer.Deserialize<Asset>(json, _options);
+    }
+
+    /// <summary>
     ///     Tests that deserialization throws JsonException when JSON is not an object.
     ///     Verifies proper error handling for invalid JSON token types.
     /// </summary>

--- a/StellarDotnetSdk.Tests/Converters/AssetJsonConverterTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/AssetJsonConverterTest.cs
@@ -143,12 +143,12 @@ public class AssetJsonConverterTest
     }
 
     /// <summary>
-    ///     Tests that deserialization throws ArgumentException when asset_type property is missing.
+    ///     Tests that deserialization throws JsonException when asset_type property is missing.
     ///     Verifies proper error handling for invalid JSON structure.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public void Deserialize_WithMissingAssetType_ThrowsArgumentException()
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithMissingAssetType_ThrowsJsonException()
     {
         // Arrange
         var json =
@@ -159,12 +159,12 @@ public class AssetJsonConverterTest
     }
 
     /// <summary>
-    ///     Tests that deserialization throws ArgumentException when credit asset is missing asset_code property.
+    ///     Tests that deserialization throws JsonException when credit asset is missing asset_code property.
     ///     Verifies validation for required properties on non-native assets.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public void Deserialize_WithNonNativeMissingCode_ThrowsArgumentException()
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithNonNativeMissingCode_ThrowsJsonException()
     {
         // Arrange
         var json =
@@ -175,12 +175,12 @@ public class AssetJsonConverterTest
     }
 
     /// <summary>
-    ///     Tests that deserialization throws ArgumentException when credit asset is missing asset_issuer property.
+    ///     Tests that deserialization throws JsonException when credit asset is missing asset_issuer property.
     ///     Verifies validation for required properties on non-native assets.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public void Deserialize_WithNonNativeMissingIssuer_ThrowsArgumentException()
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithNonNativeMissingIssuer_ThrowsJsonException()
     {
         // Arrange
         var json = @"{""asset_type"":""credit_alphanum4"",""asset_code"":""USD""}";

--- a/StellarDotnetSdk.Tests/Converters/AssetJsonConverterTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/AssetJsonConverterTest.cs
@@ -268,4 +268,39 @@ public class AssetJsonConverterTest
         Assert.AreEqual("TESTTEST", creditAsset.Code);
         Assert.AreEqual(issuer.AccountId, creditAsset.Issuer);
     }
+
+    /// <summary>
+    ///     Verifies that an unrecognized property with an object value is skipped whole: its nested keys
+    ///     must not be walked as if they were top-level (which would trip the duplicate-property guard
+    ///     on names like asset_type that legitimately appear inside nested objects).
+    /// </summary>
+    [TestMethod]
+    public void Deserialize_WithUnknownObjectProperty_IgnoresIt()
+    {
+        // Arrange
+        var json = @"{""asset_type"":""native"",""extra"":{""asset_type"":""credit_alphanum4""}}";
+
+        // Act
+        var result = JsonSerializer.Deserialize<Asset>(json, _options);
+
+        // Assert
+        Assert.IsInstanceOfType(result, typeof(AssetTypeNative));
+    }
+
+    /// <summary>
+    ///     Verifies that an unrecognized property with an array value is skipped whole, including the
+    ///     keys of any objects inside the array.
+    /// </summary>
+    [TestMethod]
+    public void Deserialize_WithUnknownArrayProperty_IgnoresIt()
+    {
+        // Arrange
+        var json = @"{""asset_type"":""native"",""extra"":[{""asset_code"":""EVL""},42]}";
+
+        // Act
+        var result = JsonSerializer.Deserialize<Asset>(json, _options);
+
+        // Assert
+        Assert.IsInstanceOfType(result, typeof(AssetTypeNative));
+    }
 }

--- a/StellarDotnetSdk.Tests/Converters/DuplicatePropertyRejectionTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/DuplicatePropertyRejectionTest.cs
@@ -1,0 +1,415 @@
+using System.Text.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StellarDotnetSdk.Accounts;
+using StellarDotnetSdk.Assets;
+using StellarDotnetSdk.Converters;
+using StellarDotnetSdk.Responses;
+using StellarDotnetSdk.Responses.Effects;
+using StellarDotnetSdk.Responses.Operations;
+using StellarDotnetSdk.Responses.Predicates;
+
+namespace StellarDotnetSdk.Tests.Converters;
+
+/// <summary>
+///     Regression tests: converters that hand-parse JSON must reject duplicate properties.
+///     The SDK-wide <c>AllowDuplicateProperties = false</c> guard on <see cref="JsonOptions.DefaultOptions" />
+///     is enforced by the built-in object mapper only; converters that read fields manually (via
+///     <see cref="JsonDocument" /> or a raw <see cref="Utf8JsonReader" /> loop) are last-wins by default,
+///     which would let a duplicated financial field (amount, asset code, time-lock predicate, pagination
+///     href) be silently overridden by the last — potentially attacker-appended — value.
+/// </summary>
+[TestClass]
+public class DuplicatePropertyRejectionTest
+{
+    private readonly JsonSerializerOptions _options = JsonOptions.DefaultOptions;
+
+    #region AssetAmount
+
+    /// <summary>
+    ///     Verifies that a duplicated amount property is rejected instead of the last value winning.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void AssetAmount_WithDuplicateAmount_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""asset"":""native"",""amount"":""1.0"",""amount"":""999999.0""}";
+
+        // Act
+        JsonSerializer.Deserialize<AssetAmount>(json, _options);
+    }
+
+    /// <summary>
+    ///     Verifies that a duplicated asset property is rejected instead of the last value winning.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void AssetAmount_WithDuplicateAsset_ThrowsJsonException()
+    {
+        // Arrange
+        var issuer = KeyPair.Random();
+        var json = $@"{{""asset"":""native"",""asset"":""USD:{issuer.AccountId}"",""amount"":""1.0""}}";
+
+        // Act
+        JsonSerializer.Deserialize<AssetAmount>(json, _options);
+    }
+
+    /// <summary>
+    ///     Verifies that duplicates are detected case-insensitively, matching the serializer-level
+    ///     guard under PropertyNameCaseInsensitive = true.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void AssetAmount_WithCaseInsensitiveDuplicateAmount_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""asset"":""native"",""amount"":""1.0"",""Amount"":""999999.0""}";
+
+        // Act
+        JsonSerializer.Deserialize<AssetAmount>(json, _options);
+    }
+
+    #endregion
+
+    #region Reserve
+
+    /// <summary>
+    ///     Verifies that a duplicated amount property is rejected instead of the last value winning.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Reserve_WithDuplicateAmount_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""asset"":""native"",""amount"":""1.0"",""amount"":""999999.0""}";
+
+        // Act
+        JsonSerializer.Deserialize<Reserve>(json, _options);
+    }
+
+    /// <summary>
+    ///     Verifies that a duplicated asset property is rejected instead of the last value winning.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Reserve_WithDuplicateAsset_ThrowsJsonException()
+    {
+        // Arrange
+        var issuer = KeyPair.Random();
+        var json = $@"{{""asset"":""native"",""asset"":""USD:{issuer.AccountId}"",""amount"":""1.0""}}";
+
+        // Act
+        JsonSerializer.Deserialize<Reserve>(json, _options);
+    }
+
+    /// <summary>
+    ///     Verifies that duplicates are detected case-insensitively, matching the serializer-level
+    ///     guard under PropertyNameCaseInsensitive = true.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Reserve_WithCaseInsensitiveDuplicateAsset_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""asset"":""native"",""Asset"":""native"",""amount"":""1.0""}";
+
+        // Act
+        JsonSerializer.Deserialize<Reserve>(json, _options);
+    }
+
+    #endregion
+
+    #region LiquidityPoolClaimableAssetAmount
+
+    /// <summary>
+    ///     Verifies that a duplicated amount property is rejected instead of the last value winning.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void LiquidityPoolClaimableAssetAmount_WithDuplicateAmount_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""asset"":""native"",""amount"":""1.0"",""amount"":""999999.0""}";
+
+        // Act
+        JsonSerializer.Deserialize<LiquidityPoolClaimableAssetAmount>(json, _options);
+    }
+
+    /// <summary>
+    ///     Verifies that a duplicated asset property is rejected instead of the last value winning.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void LiquidityPoolClaimableAssetAmount_WithDuplicateAsset_ThrowsJsonException()
+    {
+        // Arrange
+        var issuer = KeyPair.Random();
+        var json =
+            $@"{{""asset"":""native"",""asset"":""USD:{issuer.AccountId}"",""amount"":""1.0"",""claimable_balance_id"":""00000000""}}";
+
+        // Act
+        JsonSerializer.Deserialize<LiquidityPoolClaimableAssetAmount>(json, _options);
+    }
+
+    /// <summary>
+    ///     Verifies that a duplicated claimable_balance_id property is rejected instead of the last value winning.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void LiquidityPoolClaimableAssetAmount_WithDuplicateClaimableBalanceId_ThrowsJsonException()
+    {
+        // Arrange
+        var json =
+            @"{""asset"":""native"",""amount"":""1.0"",""claimable_balance_id"":""00000000"",""claimable_balance_id"":""ffffffff""}";
+
+        // Act
+        JsonSerializer.Deserialize<LiquidityPoolClaimableAssetAmount>(json, _options);
+    }
+
+    #endregion
+
+    #region Asset
+
+    /// <summary>
+    ///     Verifies that a duplicated asset_code property is rejected instead of the last value winning
+    ///     (asset-code substitution).
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Asset_WithDuplicateAssetCode_ThrowsJsonException()
+    {
+        // Arrange
+        var issuer = KeyPair.Random();
+        var json =
+            $@"{{""asset_type"":""credit_alphanum4"",""asset_code"":""USD"",""asset_code"":""EVL"",""asset_issuer"":""{issuer.AccountId}""}}";
+
+        // Act
+        JsonSerializer.Deserialize<Asset>(json, _options);
+    }
+
+    /// <summary>
+    ///     Verifies that a duplicated asset_issuer property is rejected instead of the last value winning.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Asset_WithDuplicateAssetIssuer_ThrowsJsonException()
+    {
+        // Arrange
+        var issuer = KeyPair.Random();
+        var attacker = KeyPair.Random();
+        var json =
+            $@"{{""asset_type"":""credit_alphanum4"",""asset_code"":""USD"",""asset_issuer"":""{issuer.AccountId}"",""asset_issuer"":""{attacker.AccountId}""}}";
+
+        // Act
+        JsonSerializer.Deserialize<Asset>(json, _options);
+    }
+
+    /// <summary>
+    ///     Verifies that a duplicated asset_type property is rejected instead of the last value winning.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Asset_WithDuplicateAssetType_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""asset_type"":""credit_alphanum4"",""asset_type"":""native""}";
+
+        // Act
+        JsonSerializer.Deserialize<Asset>(json, _options);
+    }
+
+    #endregion
+
+    #region Predicate
+
+    /// <summary>
+    ///     Verifies that a duplicated abs_before property is rejected instead of the last value winning
+    ///     (claimable-balance spend-window shift).
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Predicate_WithDuplicateAbsBefore_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""abs_before"":""2020-01-01T00:00:00Z"",""abs_before"":""2999-12-31T23:59:59Z""}";
+
+        // Act
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
+    ///     Verifies that a duplicated abs_before_epoch property is rejected instead of the last value winning.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Predicate_WithDuplicateAbsBeforeEpoch_ThrowsJsonException()
+    {
+        // Arrange
+        var json =
+            @"{""abs_before"":""2020-01-01T00:00:00Z"",""abs_before_epoch"":1577836800,""abs_before_epoch"":32503680000}";
+
+        // Act
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
+    ///     Verifies that a duplicated rel_before property is rejected instead of the last value winning.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Predicate_WithDuplicateRelBefore_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""rel_before"":100,""rel_before"":999999999}";
+
+        // Act
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
+    ///     Verifies that a duplicated not property is rejected instead of one of the values winning.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Predicate_WithDuplicateNot_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""not"":{""unconditional"":true},""not"":{""rel_before"":100}}";
+
+        // Act
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
+    ///     Verifies that duplicates nested inside a composite predicate are rejected too
+    ///     (the guard applies at every recursion level).
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Predicate_WithNestedDuplicateAbsBefore_ThrowsJsonException()
+    {
+        // Arrange
+        var json =
+            @"{""not"":{""abs_before"":""2020-01-01T00:00:00Z"",""abs_before"":""2999-12-31T23:59:59Z""}}";
+
+        // Act
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
+    ///     Verifies that duplicates nested inside an element of an and array are rejected too
+    ///     (elements re-enter the converter, so the guard applies inside composite arrays as well).
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Predicate_WithDuplicateInsideAndArrayElement_ThrowsJsonException()
+    {
+        // Arrange
+        var json =
+            @"{""and"":[{""abs_before"":""2020-01-01T00:00:00Z"",""abs_before"":""2999-12-31T23:59:59Z""},{""unconditional"":true}]}";
+
+        // Act
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
+    ///     Verifies that duplicates nested inside an element of an or array are rejected too.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Predicate_WithDuplicateInsideOrArrayElement_ThrowsJsonException()
+    {
+        // Arrange
+        var json =
+            @"{""or"":[{""unconditional"":true},{""rel_before"":100,""rel_before"":999999999}]}";
+
+        // Act
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    #endregion
+
+    #region Polymorphic OperationResponse / EffectResponse
+
+    /// <summary>
+    ///     Verifies that a duplicated financial field on the polymorphic operation path is rejected.
+    ///     OperationResponseJsonConverter reads only the type_i discriminator by hand and re-deserializes
+    ///     the payload through the object mapper, whose AllowDuplicateProperties = false guard must reject
+    ///     the duplicate — this is the load-bearing assumption for not giving these converters a manual guard.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void OperationResponse_WithDuplicateAmount_ThrowsJsonException()
+    {
+        // Arrange - type_i 1 = payment
+        var json = @"{""type_i"":1,""amount"":""1.0"",""amount"":""999999.0""}";
+
+        // Act
+        JsonSerializer.Deserialize<OperationResponse>(json, _options);
+    }
+
+    /// <summary>
+    ///     Verifies that a duplicated type_i discriminator on the polymorphic operation path is rejected
+    ///     by the mapper re-parse (no type-confusion via a repeated discriminator).
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void OperationResponse_WithDuplicateTypeI_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""type_i"":1,""type_i"":0,""amount"":""1.0""}";
+
+        // Act
+        JsonSerializer.Deserialize<OperationResponse>(json, _options);
+    }
+
+    /// <summary>
+    ///     Verifies that a duplicated financial field on the polymorphic effect path is rejected
+    ///     (same transitive mapper-level protection as the operation path).
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void EffectResponse_WithDuplicateAmount_ThrowsJsonException()
+    {
+        // Arrange - type_i 2 = account_credited
+        var json = @"{""type_i"":2,""amount"":""1.0"",""amount"":""999999.0""}";
+
+        // Act
+        JsonSerializer.Deserialize<EffectResponse>(json, _options);
+    }
+
+    #endregion
+
+    #region Link
+
+    /// <summary>
+    ///     Verifies that a duplicated href property is rejected instead of the last value winning
+    ///     (pagination URL substitution via _links.next).
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Link_WithDuplicateHref_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""href"":""https://horizon.stellar.org/accounts"",""href"":""https://evil.example.com/accounts""}";
+
+        // Act
+        JsonSerializer.Deserialize<Link<Response>>(json, _options);
+    }
+
+    /// <summary>
+    ///     Verifies that a duplicated templated property is rejected instead of the last value winning.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Link_WithDuplicateTemplated_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""href"":""https://horizon.stellar.org/accounts"",""templated"":false,""templated"":true}";
+
+        // Act
+        JsonSerializer.Deserialize<Link<Response>>(json, _options);
+    }
+
+    #endregion
+}

--- a/StellarDotnetSdk.Tests/Converters/DuplicatePropertyRejectionTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/DuplicatePropertyRejectionTest.cs
@@ -18,10 +18,30 @@ namespace StellarDotnetSdk.Tests.Converters;
 ///     which would let a duplicated financial field (amount, asset code, time-lock predicate, pagination
 ///     href) be silently overridden by the last — potentially attacker-appended — value.
 /// </summary>
+/// <remarks>
+///     Every case asserts through <see cref="AssertRejectsDuplicate{T}" />, which requires both a
+///     <see cref="JsonException" /> and that its message names a duplicate property. That message check is
+///     load-bearing: a bare <c>ExpectedException(typeof(JsonException))</c> would also pass if the payload
+///     failed for an unrelated reason (missing field, bad asset format), so it could stay green even if the
+///     duplicate guard were removed. Asserting the message ties each test to the guard it is meant to cover.
+/// </remarks>
 [TestClass]
 public class DuplicatePropertyRejectionTest
 {
     private readonly JsonSerializerOptions _options = JsonOptions.DefaultOptions;
+
+    /// <summary>
+    ///     Asserts that deserializing <paramref name="json" /> as <typeparamref name="T" /> fails with a
+    ///     <see cref="JsonException" /> whose message names a duplicate property — i.e. the rejection comes
+    ///     from the duplicate-property guard (converter-level or the object mapper's), not from some other
+    ///     validation failure that merely happens to throw <see cref="JsonException" />.
+    /// </summary>
+    private void AssertRejectsDuplicate<T>(string json)
+    {
+        var exception = Assert.ThrowsException<JsonException>(() => JsonSerializer.Deserialize<T>(json, _options));
+        StringAssert.Contains(exception.Message, "Duplicate property",
+            $"Expected a duplicate-property rejection, but got a different JsonException: {exception.Message}");
+    }
 
     #region AssetAmount
 
@@ -29,29 +49,23 @@ public class DuplicatePropertyRejectionTest
     ///     Verifies that a duplicated amount property is rejected instead of the last value winning.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void AssetAmount_WithDuplicateAmount_ThrowsJsonException()
     {
-        // Arrange
         var json = @"{""asset"":""native"",""amount"":""1.0"",""amount"":""999999.0""}";
 
-        // Act
-        JsonSerializer.Deserialize<AssetAmount>(json, _options);
+        AssertRejectsDuplicate<AssetAmount>(json);
     }
 
     /// <summary>
     ///     Verifies that a duplicated asset property is rejected instead of the last value winning.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void AssetAmount_WithDuplicateAsset_ThrowsJsonException()
     {
-        // Arrange
         var issuer = KeyPair.Random();
         var json = $@"{{""asset"":""native"",""asset"":""USD:{issuer.AccountId}"",""amount"":""1.0""}}";
 
-        // Act
-        JsonSerializer.Deserialize<AssetAmount>(json, _options);
+        AssertRejectsDuplicate<AssetAmount>(json);
     }
 
     /// <summary>
@@ -59,14 +73,11 @@ public class DuplicatePropertyRejectionTest
     ///     guard under PropertyNameCaseInsensitive = true.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void AssetAmount_WithCaseInsensitiveDuplicateAmount_ThrowsJsonException()
     {
-        // Arrange
         var json = @"{""asset"":""native"",""amount"":""1.0"",""Amount"":""999999.0""}";
 
-        // Act
-        JsonSerializer.Deserialize<AssetAmount>(json, _options);
+        AssertRejectsDuplicate<AssetAmount>(json);
     }
 
     #endregion
@@ -77,29 +88,23 @@ public class DuplicatePropertyRejectionTest
     ///     Verifies that a duplicated amount property is rejected instead of the last value winning.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Reserve_WithDuplicateAmount_ThrowsJsonException()
     {
-        // Arrange
         var json = @"{""asset"":""native"",""amount"":""1.0"",""amount"":""999999.0""}";
 
-        // Act
-        JsonSerializer.Deserialize<Reserve>(json, _options);
+        AssertRejectsDuplicate<Reserve>(json);
     }
 
     /// <summary>
     ///     Verifies that a duplicated asset property is rejected instead of the last value winning.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Reserve_WithDuplicateAsset_ThrowsJsonException()
     {
-        // Arrange
         var issuer = KeyPair.Random();
         var json = $@"{{""asset"":""native"",""asset"":""USD:{issuer.AccountId}"",""amount"":""1.0""}}";
 
-        // Act
-        JsonSerializer.Deserialize<Reserve>(json, _options);
+        AssertRejectsDuplicate<Reserve>(json);
     }
 
     /// <summary>
@@ -107,14 +112,11 @@ public class DuplicatePropertyRejectionTest
     ///     guard under PropertyNameCaseInsensitive = true.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Reserve_WithCaseInsensitiveDuplicateAsset_ThrowsJsonException()
     {
-        // Arrange
         var json = @"{""asset"":""native"",""Asset"":""native"",""amount"":""1.0""}";
 
-        // Act
-        JsonSerializer.Deserialize<Reserve>(json, _options);
+        AssertRejectsDuplicate<Reserve>(json);
     }
 
     #endregion
@@ -125,45 +127,36 @@ public class DuplicatePropertyRejectionTest
     ///     Verifies that a duplicated amount property is rejected instead of the last value winning.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void LiquidityPoolClaimableAssetAmount_WithDuplicateAmount_ThrowsJsonException()
     {
-        // Arrange
         var json = @"{""asset"":""native"",""amount"":""1.0"",""amount"":""999999.0""}";
 
-        // Act
-        JsonSerializer.Deserialize<LiquidityPoolClaimableAssetAmount>(json, _options);
+        AssertRejectsDuplicate<LiquidityPoolClaimableAssetAmount>(json);
     }
 
     /// <summary>
     ///     Verifies that a duplicated asset property is rejected instead of the last value winning.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void LiquidityPoolClaimableAssetAmount_WithDuplicateAsset_ThrowsJsonException()
     {
-        // Arrange
         var issuer = KeyPair.Random();
         var json =
             $@"{{""asset"":""native"",""asset"":""USD:{issuer.AccountId}"",""amount"":""1.0"",""claimable_balance_id"":""00000000""}}";
 
-        // Act
-        JsonSerializer.Deserialize<LiquidityPoolClaimableAssetAmount>(json, _options);
+        AssertRejectsDuplicate<LiquidityPoolClaimableAssetAmount>(json);
     }
 
     /// <summary>
     ///     Verifies that a duplicated claimable_balance_id property is rejected instead of the last value winning.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void LiquidityPoolClaimableAssetAmount_WithDuplicateClaimableBalanceId_ThrowsJsonException()
     {
-        // Arrange
         var json =
             @"{""asset"":""native"",""amount"":""1.0"",""claimable_balance_id"":""00000000"",""claimable_balance_id"":""ffffffff""}";
 
-        // Act
-        JsonSerializer.Deserialize<LiquidityPoolClaimableAssetAmount>(json, _options);
+        AssertRejectsDuplicate<LiquidityPoolClaimableAssetAmount>(json);
     }
 
     #endregion
@@ -175,47 +168,38 @@ public class DuplicatePropertyRejectionTest
     ///     (asset-code substitution).
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Asset_WithDuplicateAssetCode_ThrowsJsonException()
     {
-        // Arrange
         var issuer = KeyPair.Random();
         var json =
             $@"{{""asset_type"":""credit_alphanum4"",""asset_code"":""USD"",""asset_code"":""EVL"",""asset_issuer"":""{issuer.AccountId}""}}";
 
-        // Act
-        JsonSerializer.Deserialize<Asset>(json, _options);
+        AssertRejectsDuplicate<Asset>(json);
     }
 
     /// <summary>
     ///     Verifies that a duplicated asset_issuer property is rejected instead of the last value winning.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Asset_WithDuplicateAssetIssuer_ThrowsJsonException()
     {
-        // Arrange
         var issuer = KeyPair.Random();
         var attacker = KeyPair.Random();
         var json =
             $@"{{""asset_type"":""credit_alphanum4"",""asset_code"":""USD"",""asset_issuer"":""{issuer.AccountId}"",""asset_issuer"":""{attacker.AccountId}""}}";
 
-        // Act
-        JsonSerializer.Deserialize<Asset>(json, _options);
+        AssertRejectsDuplicate<Asset>(json);
     }
 
     /// <summary>
     ///     Verifies that a duplicated asset_type property is rejected instead of the last value winning.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Asset_WithDuplicateAssetType_ThrowsJsonException()
     {
-        // Arrange
         var json = @"{""asset_type"":""credit_alphanum4"",""asset_type"":""native""}";
 
-        // Act
-        JsonSerializer.Deserialize<Asset>(json, _options);
+        AssertRejectsDuplicate<Asset>(json);
     }
 
     #endregion
@@ -227,57 +211,45 @@ public class DuplicatePropertyRejectionTest
     ///     (claimable-balance spend-window shift).
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Predicate_WithDuplicateAbsBefore_ThrowsJsonException()
     {
-        // Arrange
         var json = @"{""abs_before"":""2020-01-01T00:00:00Z"",""abs_before"":""2999-12-31T23:59:59Z""}";
 
-        // Act
-        JsonSerializer.Deserialize<Predicate>(json, _options);
+        AssertRejectsDuplicate<Predicate>(json);
     }
 
     /// <summary>
     ///     Verifies that a duplicated abs_before_epoch property is rejected instead of the last value winning.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Predicate_WithDuplicateAbsBeforeEpoch_ThrowsJsonException()
     {
-        // Arrange
         var json =
             @"{""abs_before"":""2020-01-01T00:00:00Z"",""abs_before_epoch"":1577836800,""abs_before_epoch"":32503680000}";
 
-        // Act
-        JsonSerializer.Deserialize<Predicate>(json, _options);
+        AssertRejectsDuplicate<Predicate>(json);
     }
 
     /// <summary>
     ///     Verifies that a duplicated rel_before property is rejected instead of the last value winning.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Predicate_WithDuplicateRelBefore_ThrowsJsonException()
     {
-        // Arrange
         var json = @"{""rel_before"":100,""rel_before"":999999999}";
 
-        // Act
-        JsonSerializer.Deserialize<Predicate>(json, _options);
+        AssertRejectsDuplicate<Predicate>(json);
     }
 
     /// <summary>
     ///     Verifies that a duplicated not property is rejected instead of one of the values winning.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Predicate_WithDuplicateNot_ThrowsJsonException()
     {
-        // Arrange
         var json = @"{""not"":{""unconditional"":true},""not"":{""rel_before"":100}}";
 
-        // Act
-        JsonSerializer.Deserialize<Predicate>(json, _options);
+        AssertRejectsDuplicate<Predicate>(json);
     }
 
     /// <summary>
@@ -285,15 +257,12 @@ public class DuplicatePropertyRejectionTest
     ///     (the guard applies at every recursion level).
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Predicate_WithNestedDuplicateAbsBefore_ThrowsJsonException()
     {
-        // Arrange
         var json =
             @"{""not"":{""abs_before"":""2020-01-01T00:00:00Z"",""abs_before"":""2999-12-31T23:59:59Z""}}";
 
-        // Act
-        JsonSerializer.Deserialize<Predicate>(json, _options);
+        AssertRejectsDuplicate<Predicate>(json);
     }
 
     /// <summary>
@@ -301,30 +270,24 @@ public class DuplicatePropertyRejectionTest
     ///     (elements re-enter the converter, so the guard applies inside composite arrays as well).
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Predicate_WithDuplicateInsideAndArrayElement_ThrowsJsonException()
     {
-        // Arrange
         var json =
             @"{""and"":[{""abs_before"":""2020-01-01T00:00:00Z"",""abs_before"":""2999-12-31T23:59:59Z""},{""unconditional"":true}]}";
 
-        // Act
-        JsonSerializer.Deserialize<Predicate>(json, _options);
+        AssertRejectsDuplicate<Predicate>(json);
     }
 
     /// <summary>
     ///     Verifies that duplicates nested inside an element of an or array are rejected too.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Predicate_WithDuplicateInsideOrArrayElement_ThrowsJsonException()
     {
-        // Arrange
         var json =
             @"{""or"":[{""unconditional"":true},{""rel_before"":100,""rel_before"":999999999}]}";
 
-        // Act
-        JsonSerializer.Deserialize<Predicate>(json, _options);
+        AssertRejectsDuplicate<Predicate>(json);
     }
 
     #endregion
@@ -338,14 +301,12 @@ public class DuplicatePropertyRejectionTest
     ///     the duplicate — this is the load-bearing assumption for not giving these converters a manual guard.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void OperationResponse_WithDuplicateAmount_ThrowsJsonException()
     {
-        // Arrange - type_i 1 = payment
+        // type_i 1 = payment
         var json = @"{""type_i"":1,""amount"":""1.0"",""amount"":""999999.0""}";
 
-        // Act
-        JsonSerializer.Deserialize<OperationResponse>(json, _options);
+        AssertRejectsDuplicate<OperationResponse>(json);
     }
 
     /// <summary>
@@ -353,14 +314,11 @@ public class DuplicatePropertyRejectionTest
     ///     by the mapper re-parse (no type-confusion via a repeated discriminator).
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void OperationResponse_WithDuplicateTypeI_ThrowsJsonException()
     {
-        // Arrange
         var json = @"{""type_i"":1,""type_i"":0,""amount"":""1.0""}";
 
-        // Act
-        JsonSerializer.Deserialize<OperationResponse>(json, _options);
+        AssertRejectsDuplicate<OperationResponse>(json);
     }
 
     /// <summary>
@@ -368,14 +326,12 @@ public class DuplicatePropertyRejectionTest
     ///     (same transitive mapper-level protection as the operation path).
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void EffectResponse_WithDuplicateAmount_ThrowsJsonException()
     {
-        // Arrange - type_i 2 = account_credited
+        // type_i 2 = account_credited
         var json = @"{""type_i"":2,""amount"":""1.0"",""amount"":""999999.0""}";
 
-        // Act
-        JsonSerializer.Deserialize<EffectResponse>(json, _options);
+        AssertRejectsDuplicate<EffectResponse>(json);
     }
 
     #endregion
@@ -387,28 +343,22 @@ public class DuplicatePropertyRejectionTest
     ///     (pagination URL substitution via _links.next).
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Link_WithDuplicateHref_ThrowsJsonException()
     {
-        // Arrange
         var json = @"{""href"":""https://horizon.stellar.org/accounts"",""href"":""https://evil.example.com/accounts""}";
 
-        // Act
-        JsonSerializer.Deserialize<Link<Response>>(json, _options);
+        AssertRejectsDuplicate<Link<Response>>(json);
     }
 
     /// <summary>
     ///     Verifies that a duplicated templated property is rejected instead of the last value winning.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Link_WithDuplicateTemplated_ThrowsJsonException()
     {
-        // Arrange
         var json = @"{""href"":""https://horizon.stellar.org/accounts"",""templated"":false,""templated"":true}";
 
-        // Act
-        JsonSerializer.Deserialize<Link<Response>>(json, _options);
+        AssertRejectsDuplicate<Link<Response>>(json);
     }
 
     #endregion

--- a/StellarDotnetSdk.Tests/Converters/JsonOptionsTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/JsonOptionsTest.cs
@@ -12,11 +12,10 @@ namespace StellarDotnetSdk.Tests.Converters;
 [TestClass]
 public class JsonOptionsTest
 {
-    // AllowDuplicateProperties is only available (and enabled by JsonOptions) on net10.0+.
-#if NET10_0_OR_GREATER
     /// <summary>
     ///     The shared options must disable <c>AllowDuplicateProperties</c> so malformed JSON
-    ///     cannot silently overwrite financial fields.
+    ///     cannot silently overwrite financial fields. Available on every TFM via the
+    ///     System.Text.Json 10.x package reference on net8.0/netstandard2.1.
     /// </summary>
     [TestMethod]
     public void DefaultOptions_DisablesAllowDuplicateProperties()
@@ -49,7 +48,6 @@ public class JsonOptionsTest
         Assert.ThrowsException<JsonException>(() =>
             JsonSerializer.Deserialize<Payment>(json, JsonOptions.DefaultOptions));
     }
-#endif
 
     /// <summary>
     ///     Well-formed JSON without duplicates must still deserialize successfully so that
@@ -75,8 +73,6 @@ public class JsonOptionsTest
         Assert.AreEqual("100.00", payment.Amount);
     }
 
-    // AllowDuplicateProperties is only available (and enabled by JsonOptions) on net10.0+.
-#if NET10_0_OR_GREATER
     /// <summary>
     ///     Case-insensitive matching is also in effect, so two properties that differ only in
     ///     casing must still be rejected as duplicates.
@@ -97,10 +93,7 @@ public class JsonOptionsTest
         Assert.ThrowsException<JsonException>(() =>
             JsonSerializer.Deserialize<Payment>(json, JsonOptions.DefaultOptions));
     }
-#endif
 
-    // RespectNullableAnnotations is only available (and enabled by JsonOptions) on net10.0+.
-#if NET10_0_OR_GREATER
     /// <summary>
     ///     Verifies that <see cref="JsonOptions.DefaultOptions" /> has
     ///     <see cref="JsonSerializerOptions.RespectNullableAnnotations" /> enabled.
@@ -126,7 +119,6 @@ public class JsonOptionsTest
         Assert.ThrowsException<JsonException>(() =>
             JsonSerializer.Deserialize<SampleDto>(json, JsonOptions.DefaultOptions));
     }
-#endif
 
     /// <summary>
     ///     Tests deserialization of JSON where a nullable reference property is null.

--- a/StellarDotnetSdk.Tests/Converters/LiquidityPoolClaimableAssetAmountJsonConverterTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/LiquidityPoolClaimableAssetAmountJsonConverterTest.cs
@@ -231,6 +231,25 @@ public class LiquidityPoolClaimableAssetAmountJsonConverterTest
     }
 
     /// <summary>
+    ///     Verifies that deserializing JSON with empty asset property throws JsonException. Mirrors the
+    ///     empty-amount test; Read rejects both empty asset and empty amount with the same guard.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithEmptyAsset_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{
+            ""asset"":"""",
+            ""amount"":""999.99"",
+            ""claimable_balance_id"":""00000000929b20b72e5890ab51c24f1cc46fa01c4f318d8d33367d24dd614cfdf5491072""
+        }";
+
+        // Act
+        JsonSerializer.Deserialize<LiquidityPoolClaimableAssetAmount>(json, _options);
+    }
+
+    /// <summary>
     ///     Verifies that serialization produces JSON with correct property names and values.
     /// </summary>
     [TestMethod]

--- a/StellarDotnetSdk.Tests/Converters/LiquidityPoolClaimableAssetAmountJsonConverterTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/LiquidityPoolClaimableAssetAmountJsonConverterTest.cs
@@ -143,11 +143,11 @@ public class LiquidityPoolClaimableAssetAmountJsonConverterTest
     }
 
     /// <summary>
-    ///     Verifies that deserializing JSON with missing asset property throws ArgumentException.
+    ///     Verifies that deserializing JSON with missing asset property throws JsonException.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public void Deserialize_WithMissingAsset_ThrowsArgumentException()
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithMissingAsset_ThrowsJsonException()
     {
         // Arrange
         var json = @"{
@@ -160,11 +160,11 @@ public class LiquidityPoolClaimableAssetAmountJsonConverterTest
     }
 
     /// <summary>
-    ///     Verifies that deserializing JSON with missing amount property throws ArgumentException.
+    ///     Verifies that deserializing JSON with missing amount property throws JsonException.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public void Deserialize_WithMissingAmount_ThrowsArgumentException()
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithMissingAmount_ThrowsJsonException()
     {
         // Arrange
         var json = @"{
@@ -177,11 +177,11 @@ public class LiquidityPoolClaimableAssetAmountJsonConverterTest
     }
 
     /// <summary>
-    ///     Verifies that deserializing JSON with null asset property throws ArgumentException.
+    ///     Verifies that deserializing JSON with null asset property throws JsonException.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public void Deserialize_WithNullAsset_ThrowsArgumentException()
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithNullAsset_ThrowsJsonException()
     {
         // Arrange
         var json = @"{
@@ -195,11 +195,11 @@ public class LiquidityPoolClaimableAssetAmountJsonConverterTest
     }
 
     /// <summary>
-    ///     Verifies that deserializing JSON with null amount property throws ArgumentException.
+    ///     Verifies that deserializing JSON with null amount property throws JsonException.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public void Deserialize_WithNullAmount_ThrowsArgumentException()
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithNullAmount_ThrowsJsonException()
     {
         // Arrange
         var json = @"{

--- a/StellarDotnetSdk.Tests/Converters/LiquidityPoolClaimableAssetAmountJsonConverterTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/LiquidityPoolClaimableAssetAmountJsonConverterTest.cs
@@ -213,6 +213,24 @@ public class LiquidityPoolClaimableAssetAmountJsonConverterTest
     }
 
     /// <summary>
+    ///     Verifies that deserializing JSON with empty amount property throws JsonException.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithEmptyAmount_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{
+            ""asset"":""native"",
+            ""amount"":"""",
+            ""claimable_balance_id"":""00000000929b20b72e5890ab51c24f1cc46fa01c4f318d8d33367d24dd614cfdf5491072""
+        }";
+
+        // Act
+        JsonSerializer.Deserialize<LiquidityPoolClaimableAssetAmount>(json, _options);
+    }
+
+    /// <summary>
     ///     Verifies that serialization produces JSON with correct property names and values.
     /// </summary>
     [TestMethod]

--- a/StellarDotnetSdk.Tests/Converters/PredicateJsonConverterTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/PredicateJsonConverterTest.cs
@@ -414,6 +414,128 @@ public class PredicateJsonConverterTest
     }
 
     /// <summary>
+    ///     Tests that deserialization throws JsonException (not FormatException) when rel_before is a
+    ///     non-numeric string. Malformed Horizon input must surface as the SDK's documented failure mode.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithNonNumericRelBeforeString_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""rel_before"":""notanumber""}";
+
+        // Act & Assert
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
+    ///     Tests that deserialization throws JsonException (not OverflowException) when rel_before is a
+    ///     numeric string that does not fit in a 64-bit integer.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithOverflowingRelBeforeString_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""rel_before"":""99999999999999999999999999""}";
+
+        // Act & Assert
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
+    ///     Tests that deserialization throws JsonException (not InvalidOperationException) when rel_before
+    ///     is neither a number nor a string.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithBooleanRelBefore_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""rel_before"":true}";
+
+        // Act & Assert
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
+    ///     Tests that deserialization throws JsonException (not FormatException) when rel_before is a
+    ///     fractional number, which cannot represent a whole-second duration.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithFractionalRelBefore_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""rel_before"":1.5}";
+
+        // Act & Assert
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
+    ///     Tests that deserialization throws JsonException (not FormatException) when abs_before_epoch is
+    ///     a non-numeric string.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithNonNumericAbsBeforeEpochString_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""abs_before"":""2025-12-31T23:59:59Z"",""abs_before_epoch"":""notanumber""}";
+
+        // Act & Assert
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
+    ///     Tests that deserialization throws JsonException when the and array has more than two predicates.
+    ///     Stellar's ClaimPredicate AND is strictly binary; extra elements were previously dropped silently.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithAndArrayMoreThanTwoPredicates_ThrowsJsonException()
+    {
+        // Arrange
+        var json =
+            @"{""and"":[{""unconditional"":true},{""rel_before"":3600},{""rel_before"":7200}]}";
+
+        // Act & Assert
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
+    ///     Tests that deserialization throws JsonException when the or array has more than two predicates.
+    ///     Stellar's ClaimPredicate OR is strictly binary; extra elements were previously dropped silently.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithOrArrayMoreThanTwoPredicates_ThrowsJsonException()
+    {
+        // Arrange
+        var json =
+            @"{""or"":[{""unconditional"":true},{""rel_before"":3600},{""rel_before"":7200}]}";
+
+        // Act & Assert
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
+    ///     Tests that deserialization throws JsonException (not InvalidOperationException) when the and
+    ///     property is not an array.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithNonArrayAnd_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""and"":true}";
+
+        // Act & Assert
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
     ///     Tests that serialization throws JsonException for unknown predicate type.
     ///     Verifies proper error handling when predicate type is not recognized.
     /// </summary>

--- a/StellarDotnetSdk.Tests/Converters/PredicateJsonConverterTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/PredicateJsonConverterTest.cs
@@ -489,6 +489,85 @@ public class PredicateJsonConverterTest
     }
 
     /// <summary>
+    ///     Tests that a negative rel_before is rejected. Stellar time bounds are unsigned, so a negative
+    ///     value would wrap to a nonsensical ~584-billion-year duration when cast to ulong in the rebuilt
+    ///     XDR predicate.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithNegativeRelBefore_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""rel_before"":-100}";
+
+        // Act & Assert
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
+    ///     Tests that a negative rel_before supplied as a string is rejected too (the string branch used
+    ///     NumberStyles.Integer, which permits a leading minus sign).
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithNegativeRelBeforeString_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""rel_before"":""-100""}";
+
+        // Act & Assert
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
+    ///     Tests that a negative abs_before_epoch is rejected.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithNegativeAbsBeforeEpoch_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""abs_before"":""2025-12-31T23:59:59Z"",""abs_before_epoch"":-1}";
+
+        // Act & Assert
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
+    ///     Tests that a payload supplying both abs_before and abs_before_epoch with disagreeing instants is
+    ///     rejected. A spoofed epoch must not be able to shift the claim deadline while the human-readable
+    ///     abs_before string still looks correct (the DateTime accessor prefers the epoch).
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithMismatchedAbsBeforeAndEpoch_ThrowsJsonException()
+    {
+        // Arrange - abs_before says 2020; the epoch says year 3000.
+        var json = @"{""abs_before"":""2020-01-01T00:00:00Z"",""abs_before_epoch"":32503680000}";
+
+        // Act & Assert
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
+    ///     Control case: abs_before and abs_before_epoch that denote the same instant deserialize fine, so
+    ///     the mismatch guard above cannot be firing for an unrelated reason.
+    /// </summary>
+    [TestMethod]
+    public void Deserialize_WithMatchingAbsBeforeAndEpoch_Succeeds()
+    {
+        // Arrange - 2025-12-31T23:59:59Z is exactly epoch 1767225599.
+        var json = @"{""abs_before"":""2025-12-31T23:59:59Z"",""abs_before_epoch"":1767225599}";
+
+        // Act
+        var result = (PredicateBeforeAbsoluteTime)JsonSerializer.Deserialize<Predicate>(json, _options)!;
+
+        // Assert
+        Assert.AreEqual("2025-12-31T23:59:59Z", result.AbsBefore);
+        Assert.AreEqual(1767225599L, result.AbsBeforeEpoch);
+    }
+
+    /// <summary>
     ///     Tests that deserialization throws JsonException when the and array has more than two predicates.
     ///     Stellar's ClaimPredicate AND is strictly binary; extra elements were previously dropped silently.
     /// </summary>

--- a/StellarDotnetSdk.Tests/Converters/PredicateJsonConverterTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/PredicateJsonConverterTest.cs
@@ -444,6 +444,22 @@ public class PredicateJsonConverterTest
     }
 
     /// <summary>
+    ///     Tests that deserialization throws JsonException (not OverflowException) when rel_before is a
+    ///     number literal that does not fit in a 64-bit integer. Mirrors the string-form overflow test;
+    ///     both share ReadInt64FromNumberOrString.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithOverflowingRelBefore_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""rel_before"":99999999999999999999999999}";
+
+        // Act & Assert
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
     ///     Tests that deserialization throws JsonException (not InvalidOperationException) when rel_before
     ///     is neither a number nor a string.
     /// </summary>
@@ -534,6 +550,21 @@ public class PredicateJsonConverterTest
     }
 
     /// <summary>
+    ///     Tests that a negative abs_before_epoch supplied as a string is rejected too. Mirrors the
+    ///     number-form test; both share the value &lt; 0 guard in ReadInt64FromNumberOrString.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithNegativeAbsBeforeEpochString_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""abs_before"":""2025-12-31T23:59:59Z"",""abs_before_epoch"":""-1""}";
+
+        // Act & Assert
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
     ///     Tests that a payload supplying both abs_before and abs_before_epoch with disagreeing instants is
     ///     rejected. A spoofed epoch must not be able to shift the claim deadline while the human-readable
     ///     abs_before string still looks correct (the DateTime accessor prefers the epoch).
@@ -609,6 +640,21 @@ public class PredicateJsonConverterTest
     {
         // Arrange
         var json = @"{""and"":true}";
+
+        // Act & Assert
+        JsonSerializer.Deserialize<Predicate>(json, _options);
+    }
+
+    /// <summary>
+    ///     Tests that deserialization throws JsonException (not InvalidOperationException) when the or
+    ///     property is not an array. Mirrors the non-array and test; both share DeserializePredicateArray.
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithNonArrayOr_ThrowsJsonException()
+    {
+        // Arrange
+        var json = @"{""or"":true}";
 
         // Act & Assert
         JsonSerializer.Deserialize<Predicate>(json, _options);

--- a/StellarDotnetSdk.Tests/Converters/ReserveJsonConverterTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/ReserveJsonConverterTest.cs
@@ -128,11 +128,11 @@ public class ReserveJsonConverterTest
     }
 
     /// <summary>
-    ///     Verifies that deserializing JSON with missing asset property throws ArgumentException.
+    ///     Verifies that deserializing JSON with missing asset property throws JsonException.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public void Deserialize_WithMissingAsset_ThrowsArgumentException()
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithMissingAsset_ThrowsJsonException()
     {
         // Arrange
         var json = @"{""amount"":""100""}";
@@ -142,11 +142,11 @@ public class ReserveJsonConverterTest
     }
 
     /// <summary>
-    ///     Verifies that deserializing JSON with missing amount property throws ArgumentException.
+    ///     Verifies that deserializing JSON with missing amount property throws JsonException.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public void Deserialize_WithMissingAmount_ThrowsArgumentException()
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithMissingAmount_ThrowsJsonException()
     {
         // Arrange
         var json = @"{""asset"":""native""}";
@@ -156,11 +156,11 @@ public class ReserveJsonConverterTest
     }
 
     /// <summary>
-    ///     Verifies that deserializing JSON with null asset property throws ArgumentException.
+    ///     Verifies that deserializing JSON with null asset property throws JsonException.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public void Deserialize_WithNullAsset_ThrowsArgumentException()
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithNullAsset_ThrowsJsonException()
     {
         // Arrange
         var json = @"{""asset"":null,""amount"":""100""}";
@@ -170,11 +170,11 @@ public class ReserveJsonConverterTest
     }
 
     /// <summary>
-    ///     Verifies that deserializing JSON with null amount property throws ArgumentException.
+    ///     Verifies that deserializing JSON with null amount property throws JsonException.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public void Deserialize_WithNullAmount_ThrowsArgumentException()
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithNullAmount_ThrowsJsonException()
     {
         // Arrange
         var json = @"{""asset"":""native"",""amount"":null}";
@@ -270,11 +270,11 @@ public class ReserveJsonConverterTest
     }
 
     /// <summary>
-    ///     Verifies that deserializing JSON with empty asset property throws ArgumentException.
+    ///     Verifies that deserializing JSON with empty asset property throws JsonException.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public void Deserialize_WithEmptyAsset_ThrowsArgumentException()
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithEmptyAsset_ThrowsJsonException()
     {
         // Arrange
         var json = @"{""asset"":"""",""amount"":""100""}";
@@ -284,11 +284,11 @@ public class ReserveJsonConverterTest
     }
 
     /// <summary>
-    ///     Verifies that deserializing JSON with empty amount property throws ArgumentException.
+    ///     Verifies that deserializing JSON with empty amount property throws JsonException.
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public void Deserialize_WithEmptyAmount_ThrowsArgumentException()
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithEmptyAmount_ThrowsJsonException()
     {
         // Arrange
         var json = @"{""asset"":""native"",""amount"":""""}";

--- a/StellarDotnetSdk.Tests/Converters/ReserveJsonConverterTest.cs
+++ b/StellarDotnetSdk.Tests/Converters/ReserveJsonConverterTest.cs
@@ -315,4 +315,41 @@ public class ReserveJsonConverterTest
         Assert.AreEqual("native", result.Asset.CanonicalName());
         Assert.AreEqual("100", result.Amount);
     }
+
+    /// <summary>
+    ///     Verifies that an unrecognized property with an object value is skipped whole: its nested keys
+    ///     must not be walked as if they were top-level, which would both trip the duplicate-property
+    ///     guard on names like amount and desynchronize the reader.
+    /// </summary>
+    [TestMethod]
+    public void Deserialize_WithUnknownObjectProperty_IgnoresIt()
+    {
+        // Arrange - the nested object deliberately reuses the top-level property name "amount"
+        var json = @"{""asset"":""native"",""amount"":""100"",""_links"":{""amount"":""999999""}}";
+
+        // Act
+        var result = JsonSerializer.Deserialize<Reserve>(json, _options);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual("100", result.Amount);
+    }
+
+    /// <summary>
+    ///     Verifies that an unrecognized property with an array value is skipped whole, including the
+    ///     keys of any objects inside the array.
+    /// </summary>
+    [TestMethod]
+    public void Deserialize_WithUnknownArrayProperty_IgnoresIt()
+    {
+        // Arrange
+        var json = @"{""asset"":""native"",""amount"":""100"",""extra"":[{""asset"":""EVL:G""}]}";
+
+        // Act
+        var result = JsonSerializer.Deserialize<Reserve>(json, _options);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual("100", result.Amount);
+    }
 }

--- a/StellarDotnetSdk.Tests/Responses/PredicateDeserializerTest.cs
+++ b/StellarDotnetSdk.Tests/Responses/PredicateDeserializerTest.cs
@@ -169,6 +169,43 @@ public class PredicateDeserializerTest
     }
 
     /// <summary>
+    ///     Verifies that when abs_before has no offset designator and no epoch is supplied, the DateTime
+    ///     accessor interprets the value as UTC — the same rule the converter's abs_before/abs_before_epoch
+    ///     consistency check applies — rather than the machine's local time zone.
+    /// </summary>
+    [TestMethod]
+    public void Deserialize_WithOffsetlessAbsBeforeAndNoEpoch_DateTimeAssumesUtc()
+    {
+        // Arrange
+        const string json = "{\"abs_before\":\"2020-08-26T11:15:39\"}";
+
+        // Act
+        var predicate = JsonSerializer.Deserialize<Predicate>(json, JsonOptions.DefaultOptions);
+
+        // Assert
+        var absPredicate = (PredicateBeforeAbsoluteTime)predicate!;
+        Assert.AreEqual(1598440539L, absPredicate.DateTime.ToUnixTimeSeconds());
+    }
+
+    /// <summary>
+    ///     Verifies that when abs_before carries an explicit offset and no epoch is supplied, the DateTime
+    ///     accessor preserves the denoted instant.
+    /// </summary>
+    [TestMethod]
+    public void Deserialize_WithOffsetAbsBeforeAndNoEpoch_DateTimePreservesInstant()
+    {
+        // Arrange
+        const string json = "{\"abs_before\":\"2020-08-26T13:15:39+02:00\"}";
+
+        // Act
+        var predicate = JsonSerializer.Deserialize<Predicate>(json, JsonOptions.DefaultOptions);
+
+        // Assert
+        var absPredicate = (PredicateBeforeAbsoluteTime)predicate!;
+        Assert.AreEqual(1598440539L, absPredicate.DateTime.ToUnixTimeSeconds());
+    }
+
+    /// <summary>
     ///     Verifies that PredicateBeforeAbsoluteTime can be deserialized from JSON with string epoch.
     /// </summary>
     [TestMethod]

--- a/StellarDotnetSdk.Tests/Sep/Sep0009/KycJsonSerializationTest.cs
+++ b/StellarDotnetSdk.Tests/Sep/Sep0009/KycJsonSerializationTest.cs
@@ -112,6 +112,8 @@ public class KycJsonSerializationTest
     // The following run on every TFM (including netstandard2.1) — that is the point of referencing
     // System.Text.Json 10.x on all targets: KycJsonOptions.Default must enforce the same JSON guards
     // as JsonOptions.DefaultOptions everywhere, not just on net10.0.
+    // (KycJsonOptions.Default is a public utility for consumers' own internal/persistence
+    // serialization — SEP-0009 wire parsing goes through the typed field models, not these options.)
     [TestMethod]
     public void KycJsonOptions_Default_DisablesAllowDuplicateProperties()
     {
@@ -121,6 +123,10 @@ public class KycJsonSerializationTest
     [TestMethod]
     public void KycJsonOptions_Default_RespectNullableAnnotations_IsEnabled()
     {
+        // Flag-only assertion by design: a behavioral rejection test (explicit null for a
+        // non-nullable member) is not possible against the SEP-9 models, because every property on
+        // NaturalPersonKycFields/OrganizationKycFields is nullable. The flag is the maximum
+        // meaningful coverage without a synthetic fixture DTO.
         KycJsonOptions.Default.RespectNullableAnnotations.Should().BeTrue();
     }
 
@@ -129,6 +135,30 @@ public class KycJsonSerializationTest
     {
         // A duplicated field must be rejected rather than silently taking the last value.
         var json = """{"firstName":"John","firstName":"Jane"}""";
+
+        var act = () => JsonSerializer.Deserialize<NaturalPersonKycFields>(json, KycJsonOptions.Default);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [TestMethod]
+    public void KycJsonOptions_Deserialize_OrganizationWithDuplicateProperties_ThrowsJsonException()
+    {
+        // Same guard as the NaturalPersonKycFields test above, on the organization model.
+        var json = """{"name":"Acme Corp","name":"Evil Corp"}""";
+
+        var act = () => JsonSerializer.Deserialize<OrganizationKycFields>(json, KycJsonOptions.Default);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [TestMethod]
+    public void KycJsonOptions_Deserialize_WithCaseInsensitiveDuplicateProperties_ThrowsJsonException()
+    {
+        // PropertyNameCaseInsensitive = true makes these the same logical property, so the
+        // duplicate guard must reject them despite the differing case (mirrors the equivalent
+        // JsonOptions.DefaultOptions test).
+        var json = """{"firstName":"John","FIRSTNAME":"Jane"}""";
 
         var act = () => JsonSerializer.Deserialize<NaturalPersonKycFields>(json, KycJsonOptions.Default);
 

--- a/StellarDotnetSdk.Tests/Sep/Sep0009/KycJsonSerializationTest.cs
+++ b/StellarDotnetSdk.Tests/Sep/Sep0009/KycJsonSerializationTest.cs
@@ -123,12 +123,31 @@ public class KycJsonSerializationTest
     [TestMethod]
     public void KycJsonOptions_Default_RespectNullableAnnotations_IsEnabled()
     {
-        // Flag-only assertion by design: a behavioral rejection test (explicit null for a
-        // non-nullable member) is not possible against the SEP-9 models, because every property on
-        // NaturalPersonKycFields/OrganizationKycFields is nullable. The flag is the maximum
-        // meaningful coverage without a synthetic fixture DTO.
+        // The SEP-9 models can't exercise this behaviorally (every property on
+        // NaturalPersonKycFields/OrganizationKycFields is nullable), so this asserts the flag and
+        // KycJsonOptions_Deserialize_NullForNonNullableMember_ThrowsJsonException (below) asserts the
+        // behavior via a synthetic non-nullable DTO.
         KycJsonOptions.Default.RespectNullableAnnotations.Should().BeTrue();
     }
+
+    [TestMethod]
+    public void KycJsonOptions_Deserialize_NullForNonNullableMember_ThrowsJsonException()
+    {
+        // Behavioral coverage for RespectNullableAnnotations = true through KycJsonOptions.Default:
+        // an explicit null for a non-nullable member is rejected rather than silently written.
+        var json = """{"value":null}""";
+
+        var act = () => JsonSerializer.Deserialize<NonNullableProbe>(json, KycJsonOptions.Default);
+
+        act.Should().Throw<JsonException>();
+    }
+
+#nullable enable
+    private sealed class NonNullableProbe
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+#nullable restore
 
     [TestMethod]
     public void KycJsonOptions_Deserialize_WithDuplicateProperties_ThrowsJsonException()

--- a/StellarDotnetSdk.Tests/Sep/Sep0009/KycJsonSerializationTest.cs
+++ b/StellarDotnetSdk.Tests/Sep/Sep0009/KycJsonSerializationTest.cs
@@ -108,4 +108,30 @@ public class KycJsonSerializationTest
         act.Should().Throw<JsonException>();
     }
 #endif
+
+    // The following run on every TFM (including netstandard2.1) — that is the point of referencing
+    // System.Text.Json 10.x on all targets: KycJsonOptions.Default must enforce the same JSON guards
+    // as JsonOptions.DefaultOptions everywhere, not just on net10.0.
+    [TestMethod]
+    public void KycJsonOptions_Default_DisablesAllowDuplicateProperties()
+    {
+        KycJsonOptions.Default.AllowDuplicateProperties.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void KycJsonOptions_Default_RespectNullableAnnotations_IsEnabled()
+    {
+        KycJsonOptions.Default.RespectNullableAnnotations.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void KycJsonOptions_Deserialize_WithDuplicateProperties_ThrowsJsonException()
+    {
+        // A duplicated field must be rejected rather than silently taking the last value.
+        var json = """{"firstName":"John","firstName":"Jane"}""";
+
+        var act = () => JsonSerializer.Deserialize<NaturalPersonKycFields>(json, KycJsonOptions.Default);
+
+        act.Should().Throw<JsonException>();
+    }
 }

--- a/StellarDotnetSdk/Converters/AssetAmountJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/AssetAmountJsonConverter.cs
@@ -49,7 +49,7 @@ public class AssetAmountJsonConverter : JsonConverter<AssetAmount>
             throw new JsonException($"JSON value for amount is missing in {nameof(AssetAmount)}.");
         }
         var amount = amountElement.GetString();
-        if (amount == null)
+        if (string.IsNullOrEmpty(amount))
         {
             throw new JsonException($"JSON value for amount is missing in {nameof(AssetAmount)}.");
         }

--- a/StellarDotnetSdk/Converters/AssetAmountJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/AssetAmountJsonConverter.cs
@@ -9,6 +9,13 @@ namespace StellarDotnetSdk.Converters;
 ///     JSON converter for AssetAmount.
 ///     Handles conversion between JSON objects and AssetAmount instances.
 /// </summary>
+/// <remarks>
+///     Duplicate JSON property names are always rejected with a <see cref="JsonException" />, matched
+///     case-insensitively. This is intentional hardening for financial fields and does not honor the
+///     <see cref="JsonSerializerOptions" /> passed to <see cref="Read" /> — neither
+///     <see cref="JsonSerializerOptions.AllowDuplicateProperties" /> nor
+///     <see cref="JsonSerializerOptions.PropertyNameCaseInsensitive" /> changes it.
+/// </remarks>
 public class AssetAmountJsonConverter : JsonConverter<AssetAmount>
 {
     /// <inheritdoc />
@@ -25,6 +32,7 @@ public class AssetAmountJsonConverter : JsonConverter<AssetAmount>
 
         using var jsonDocument = JsonDocument.ParseValue(ref reader);
         var jsonObject = jsonDocument.RootElement;
+        JsonDuplicatePropertyGuard.EnsureNoDuplicateProperties(jsonObject, nameof(AssetAmount));
 
         if (!jsonObject.TryGetProperty("asset", out var assetElement))
         {

--- a/StellarDotnetSdk/Converters/AssetAmountJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/AssetAmountJsonConverter.cs
@@ -36,27 +36,25 @@ public class AssetAmountJsonConverter : JsonConverter<AssetAmount>
 
         if (!jsonObject.TryGetProperty("asset", out var assetElement))
         {
-            throw new ArgumentException("JSON value for asset is missing.", nameof(assetElement));
+            throw new JsonException($"JSON value for asset is missing in {nameof(AssetAmount)}.");
         }
         var assetName = assetElement.GetString();
-        var asset = string.IsNullOrEmpty(assetName) ? null : Asset.Create(assetName);
+        if (string.IsNullOrEmpty(assetName))
+        {
+            throw new JsonException($"JSON value for asset is missing in {nameof(AssetAmount)}.");
+        }
 
         if (!jsonObject.TryGetProperty("amount", out var amountElement))
         {
-            throw new ArgumentException("JSON value for amount is missing.", nameof(amountElement));
+            throw new JsonException($"JSON value for amount is missing in {nameof(AssetAmount)}.");
         }
         var amount = amountElement.GetString();
-
-        if (asset == null)
-        {
-            throw new ArgumentException("JSON value for asset is missing.", nameof(asset));
-        }
         if (amount == null)
         {
-            throw new ArgumentException("JSON value for amount is missing.", nameof(amount));
+            throw new JsonException($"JSON value for amount is missing in {nameof(AssetAmount)}.");
         }
 
-        return new AssetAmount(asset, amount);
+        return new AssetAmount(AssetJsonReadHelper.CreateAsset(assetName), amount);
     }
 
     /// <inheritdoc />

--- a/StellarDotnetSdk/Converters/AssetJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/AssetJsonConverter.cs
@@ -96,7 +96,7 @@ public class AssetJsonConverter : JsonConverter<Asset>
         {
             throw new JsonException($"JSON value for asset_code is missing in {nameof(Asset)}.");
         }
-        if (issuer == null)
+        if (string.IsNullOrEmpty(issuer))
         {
             throw new JsonException($"JSON value for asset_issuer is missing in {nameof(Asset)}.");
         }

--- a/StellarDotnetSdk/Converters/AssetJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/AssetJsonConverter.cs
@@ -92,7 +92,7 @@ public class AssetJsonConverter : JsonConverter<Asset>
             return new AssetTypeNative();
         }
 
-        if (code == null)
+        if (string.IsNullOrEmpty(code))
         {
             throw new JsonException($"JSON value for asset_code is missing in {nameof(Asset)}.");
         }

--- a/StellarDotnetSdk/Converters/AssetJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/AssetJsonConverter.cs
@@ -9,6 +9,13 @@ namespace StellarDotnetSdk.Converters;
 ///     JSON converter for Asset.
 ///     Handles conversion between JSON objects and Asset instances (native or credit assets).
 /// </summary>
+/// <remarks>
+///     Duplicate JSON property names are always rejected with a <see cref="JsonException" />, matched
+///     case-insensitively. This is intentional hardening for financial fields and does not honor the
+///     <see cref="JsonSerializerOptions" /> passed to <see cref="Read" /> — neither
+///     <see cref="JsonSerializerOptions.AllowDuplicateProperties" /> nor
+///     <see cref="JsonSerializerOptions.PropertyNameCaseInsensitive" /> changes it.
+/// </remarks>
 public class AssetJsonConverter : JsonConverter<Asset>
 {
     /// <inheritdoc />
@@ -40,12 +47,19 @@ public class AssetJsonConverter : JsonConverter<Asset>
         string? type = null;
         string? code = null;
         string? issuer = null;
+        var seen = JsonDuplicatePropertyGuard.CreateSeenSet();
 
         while (reader.Read())
         {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                break;
+            }
+
             if (reader.TokenType == JsonTokenType.PropertyName)
             {
-                var propertyName = reader.GetString();
+                var propertyName = reader.GetString()!;
+                JsonDuplicatePropertyGuard.MarkSeen(seen, propertyName, nameof(Asset));
                 reader.Read();
                 switch (propertyName)
                 {
@@ -58,12 +72,13 @@ public class AssetJsonConverter : JsonConverter<Asset>
                     case "asset_issuer":
                         issuer = reader.GetString();
                         break;
+                    default:
+                        // Skip the whole value: an unrecognized object/array value would otherwise be
+                        // walked as if its keys were top-level Asset properties, corrupting the
+                        // duplicate guard's seen-set and desynchronizing the reader.
+                        reader.Skip();
+                        break;
                 }
-            }
-
-            if (reader.TokenType == JsonTokenType.EndObject)
-            {
-                break;
             }
         }
 

--- a/StellarDotnetSdk/Converters/AssetJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/AssetJsonConverter.cs
@@ -84,7 +84,7 @@ public class AssetJsonConverter : JsonConverter<Asset>
 
         if (type == null)
         {
-            throw new ArgumentException("JSON value for asset_type is missing.", nameof(type));
+            throw new JsonException($"JSON value for asset_type is missing in {nameof(Asset)}.");
         }
 
         if (type == "native")
@@ -94,13 +94,13 @@ public class AssetJsonConverter : JsonConverter<Asset>
 
         if (code == null)
         {
-            throw new ArgumentException("JSON value for asset_code is missing.", nameof(code));
+            throw new JsonException($"JSON value for asset_code is missing in {nameof(Asset)}.");
         }
         if (issuer == null)
         {
-            throw new ArgumentException("JSON value for asset_issuer is missing.", nameof(issuer));
+            throw new JsonException($"JSON value for asset_issuer is missing in {nameof(Asset)}.");
         }
 
-        return Asset.CreateNonNativeAsset(code, issuer);
+        return AssetJsonReadHelper.CreateNonNativeAsset(code, issuer);
     }
 }

--- a/StellarDotnetSdk/Converters/AssetJsonReadHelper.cs
+++ b/StellarDotnetSdk/Converters/AssetJsonReadHelper.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Text.Json;
+using StellarDotnetSdk.Assets;
+using StellarDotnetSdk.Exceptions;
+
+namespace StellarDotnetSdk.Converters;
+
+/// <summary>
+///     Helpers shared by the hand-written asset converters (<see cref="AssetJsonConverter" />,
+///     <see cref="AssetAmountJsonConverter" />, <see cref="ReserveJsonConverter" />,
+///     <see cref="LiquidityPoolClaimableAssetAmountJsonConverter" />) that build an <see cref="Asset" />
+///     from JSON values.
+/// </summary>
+/// <remarks>
+///     <see cref="Asset.Create(string)" /> and <see cref="Asset.CreateNonNativeAsset(string, string)" />
+///     validate the asset string/code and throw <see cref="ArgumentException" /> or
+///     <see cref="AssetCodeLengthInvalidException" /> on invalid input. A converter must instead surface
+///     deserialization failures as <see cref="JsonException" /> (the documented System.Text.Json failure
+///     mode) so a caller can handle every malformed-response failure with a single
+///     <c>catch (JsonException)</c>, so these helpers translate the factory's domain exceptions while
+///     preserving the original as <see cref="Exception.InnerException" />.
+/// </remarks>
+internal static class AssetJsonReadHelper
+{
+    /// <summary>
+    ///     Builds an <see cref="Asset" /> from its canonical string form, translating an invalid value
+    ///     into a <see cref="JsonException" />.
+    /// </summary>
+    internal static Asset CreateAsset(string canonicalName)
+    {
+        try
+        {
+            return Asset.Create(canonicalName);
+        }
+        catch (Exception exception) when (exception is ArgumentException or AssetCodeLengthInvalidException)
+        {
+            throw new JsonException($"Invalid asset value '{canonicalName}'.", exception);
+        }
+    }
+
+    /// <summary>
+    ///     Builds a non-native <see cref="Asset" /> from a code/issuer pair, translating an invalid code
+    ///     length into a <see cref="JsonException" />.
+    /// </summary>
+    internal static Asset CreateNonNativeAsset(string code, string issuer)
+    {
+        try
+        {
+            return Asset.CreateNonNativeAsset(code, issuer);
+        }
+        catch (Exception exception) when (exception is ArgumentException or AssetCodeLengthInvalidException)
+        {
+            throw new JsonException($"Invalid asset code '{code}' or issuer '{issuer}'.", exception);
+        }
+    }
+}

--- a/StellarDotnetSdk/Converters/EffectResponseJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/EffectResponseJsonConverter.cs
@@ -134,6 +134,12 @@ public class EffectResponseJsonConverter : JsonConverter<EffectResponse>
         using var document = JsonDocument.ParseValue(ref reader);
         var root = document.RootElement;
 
+        // The mapper re-parse below rejects duplicates of mapped fields, but type_i is a read-only
+        // (get-only) discriminator the mapper never binds, so a duplicated type_i would otherwise slip
+        // through and be resolved by a single hand-read. Guard the root explicitly so every duplicate —
+        // discriminator included — fails fast, consistent with the SDK's other hand-parsing converters.
+        JsonDuplicatePropertyGuard.EnsureNoDuplicateProperties(root, nameof(EffectResponse));
+
         // Extract discriminator from parsed document
         if (!root.TryGetProperty("type_i", out var typeProperty))
         {

--- a/StellarDotnetSdk/Converters/JsonDuplicatePropertyGuard.cs
+++ b/StellarDotnetSdk/Converters/JsonDuplicatePropertyGuard.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace StellarDotnetSdk.Converters;
+
+/// <summary>
+///     Rejects JSON objects that define the same property name more than once.
+/// </summary>
+/// <remarks>
+///     The SDK-wide duplicate-property guard on <see cref="JsonOptions" /> (<c>AllowDuplicateProperties = false</c>)
+///     is enforced by the built-in object mapper only; converters that hand-parse JSON via
+///     <see cref="JsonDocument" /> or a raw <see cref="Utf8JsonReader" /> loop are last-wins by default. Those
+///     converters call into this class so a duplicated field (amount, asset code, time-lock predicate,
+///     pagination href, ...) fails fast instead of being silently overridden by the last — potentially
+///     attacker-appended — value. Duplicates are detected case-insensitively, matching the object mapper's
+///     behavior under <c>PropertyNameCaseInsensitive = true</c>, and independently of the target framework's
+///     System.Text.Json version.
+/// </remarks>
+internal static class JsonDuplicatePropertyGuard
+{
+    /// <summary>
+    ///     Throws a <see cref="JsonException" /> if <paramref name="element" /> is a JSON object that defines
+    ///     the same property name (case-insensitively) more than once. Elements other than objects are ignored.
+    ///     Only the element's own properties are checked; nested objects are the responsibility of whichever
+    ///     converter consumes them.
+    /// </summary>
+    /// <param name="element">The JSON element to check.</param>
+    /// <param name="typeName">Name of the type being deserialized, used in the exception message.</param>
+    internal static void EnsureNoDuplicateProperties(JsonElement element, string typeName)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+
+        var seen = CreateSeenSet();
+        foreach (var property in element.EnumerateObject())
+        {
+            MarkSeen(seen, property.Name, typeName);
+        }
+    }
+
+    /// <summary>
+    ///     Creates the case-insensitive name set used with <see cref="MarkSeen" /> by converters that read
+    ///     properties from a raw <see cref="Utf8JsonReader" /> loop.
+    /// </summary>
+    internal static HashSet<string> CreateSeenSet()
+    {
+        return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    ///     Records <paramref name="propertyName" /> in <paramref name="seen" /> and throws a
+    ///     <see cref="JsonException" /> if it was already present (case-insensitively).
+    /// </summary>
+    /// <param name="seen">Set created by <see cref="CreateSeenSet" /> tracking the names read so far.</param>
+    /// <param name="propertyName">The property name just read.</param>
+    /// <param name="typeName">Name of the type being deserialized, used in the exception message.</param>
+    internal static void MarkSeen(HashSet<string> seen, string propertyName, string typeName)
+    {
+        if (!seen.Add(propertyName))
+        {
+            throw new JsonException($"Duplicate property '{propertyName}' in {typeName} JSON.");
+        }
+    }
+}

--- a/StellarDotnetSdk/Converters/JsonOptions.cs
+++ b/StellarDotnetSdk/Converters/JsonOptions.cs
@@ -26,8 +26,9 @@ public static class JsonOptions
     ///     Scope: the option is enforced by STJ's built-in object mapper (POCO-bound properties); converters
     ///     that hand-parse JSON (e.g. Reserve, Asset, AssetAmount) enforce the same rule themselves via
     ///     <see cref="JsonDuplicatePropertyGuard" />. The polymorphic OperationResponse/EffectResponse
-    ///     converters also hand-parse (only to read the <c>type_i</c> discriminator) but need no guard of
-    ///     their own: they re-deserialize the payload through the object mapper, which re-detects duplicates.
+    ///     converters also guard the root document themselves: re-deserializing through the object mapper
+    ///     re-detects duplicates of mapped properties, but the <c>type_i</c> discriminator they hand-read
+    ///     is get-only and never mapper-bound, so a duplicated <c>type_i</c> would otherwise slip through.
     ///     - RespectNullableAnnotations: Enforces C# nullability annotations during (de)serialization,
     ///     so malformed API responses that violate the SDK's nullability contract fail fast.
     ///     Registered Converters:
@@ -57,9 +58,10 @@ public static class JsonOptions
             // reference on net8.0/netstandard2.1 makes this option available on every TFM.
             // Note: STJ enforces this option only in its built-in object mapper. Converters registered below
             // that hand-parse JSON (Reserve, Asset, AssetAmount, LiquidityPoolClaimableAssetAmount, Predicate,
-            // Link) enforce the same rule themselves via JsonDuplicatePropertyGuard. The polymorphic
-            // OperationResponse/EffectResponse converters hand-parse only the type_i discriminator and then
-            // re-deserialize through the mapper, so duplicates on their fields are still rejected by this option.
+            // Link, OperationResponse, EffectResponse) enforce the same rule themselves via
+            // JsonDuplicatePropertyGuard. The polymorphic OperationResponse/EffectResponse converters guard
+            // the root explicitly because the mapper re-parse only re-detects duplicates of mapped fields —
+            // the get-only type_i discriminator they hand-read is never mapper-bound.
             AllowDuplicateProperties = false,
 
             // Enforce C# nullability annotations so null values for non-nullable properties are rejected

--- a/StellarDotnetSdk/Converters/JsonOptions.cs
+++ b/StellarDotnetSdk/Converters/JsonOptions.cs
@@ -20,10 +20,10 @@ public static class JsonOptions
     ///     Configuration:
     ///     - NumberHandling: Allows reading numbers from strings (API compatibility)
     ///     - PropertyNameCaseInsensitive: Allows flexible property matching
-    ///     - AllowDuplicateProperties (net10.0+ only): Rejects JSON payloads that contain the same property more than once,
+    ///     - AllowDuplicateProperties: Rejects JSON payloads that contain the same property more than once,
     ///     preventing silent data corruption from malformed responses (critical for financial data integrity).
-    ///     On net8.0/netstandard2.1 this option is unavailable; STJ uses its default duplicate-property behavior.
-    ///     - RespectNullableAnnotations (net10.0+ only): Enforces C# nullability annotations during (de)serialization,
+    ///     Available on every TFM via the System.Text.Json 10.x package reference on net8.0/netstandard2.1.
+    ///     - RespectNullableAnnotations: Enforces C# nullability annotations during (de)serialization,
     ///     so malformed API responses that violate the SDK's nullability contract fail fast.
     ///     Registered Converters:
     ///     - Polymorphic converters: OperationResponse, EffectResponse, Predicate
@@ -46,20 +46,15 @@ public static class JsonOptions
             // Case-insensitive property matching
             PropertyNameCaseInsensitive = true,
 
-            // AllowDuplicateProperties (net10.0+ only): Reject JSON payloads with duplicate property names to prevent
-            // silent data corruption. Malformed or adversarial responses could otherwise overwrite financial fields
-            // (amount, balance, destination) with attacker-controlled values without any error.
-            // On net8.0/netstandard2.1 this STJ option is unavailable; deserialization uses the runtime default
-            // (last duplicate property wins).
-#if NET10_0_OR_GREATER
+            // Reject JSON payloads with duplicate property names to prevent silent data corruption. Malformed
+            // or adversarial responses could otherwise overwrite financial fields (amount, balance, destination)
+            // with attacker-controlled values without any error. The System.Text.Json 10.x package reference on
+            // net8.0/netstandard2.1 makes this option available on every TFM.
             AllowDuplicateProperties = false,
-#endif
 
-#if NET10_0_OR_GREATER
-            // RespectNullableAnnotations (net10.0+ only): Enforce C# nullability annotations so null values for
-            // non-nullable properties are rejected during deserialization.
+            // Enforce C# nullability annotations so null values for non-nullable properties are rejected
+            // during deserialization.
             RespectNullableAnnotations = true,
-#endif
 
             Converters =
             {

--- a/StellarDotnetSdk/Converters/JsonOptions.cs
+++ b/StellarDotnetSdk/Converters/JsonOptions.cs
@@ -23,6 +23,11 @@ public static class JsonOptions
     ///     - AllowDuplicateProperties: Rejects JSON payloads that contain the same property more than once,
     ///     preventing silent data corruption from malformed responses (critical for financial data integrity).
     ///     Available on every TFM via the System.Text.Json 10.x package reference on net8.0/netstandard2.1.
+    ///     Scope: the option is enforced by STJ's built-in object mapper (POCO-bound properties); converters
+    ///     that hand-parse JSON (e.g. Reserve, Asset, AssetAmount) enforce the same rule themselves via
+    ///     <see cref="JsonDuplicatePropertyGuard" />. The polymorphic OperationResponse/EffectResponse
+    ///     converters also hand-parse (only to read the <c>type_i</c> discriminator) but need no guard of
+    ///     their own: they re-deserialize the payload through the object mapper, which re-detects duplicates.
     ///     - RespectNullableAnnotations: Enforces C# nullability annotations during (de)serialization,
     ///     so malformed API responses that violate the SDK's nullability contract fail fast.
     ///     Registered Converters:
@@ -47,9 +52,14 @@ public static class JsonOptions
             PropertyNameCaseInsensitive = true,
 
             // Reject JSON payloads with duplicate property names to prevent silent data corruption. Malformed
-            // or adversarial responses could otherwise overwrite financial fields (amount, balance, destination)
-            // with attacker-controlled values without any error. The System.Text.Json 10.x package reference on
-            // net8.0/netstandard2.1 makes this option available on every TFM.
+            // or adversarial responses could otherwise overwrite POCO-mapped financial fields (amount, balance,
+            // destination) with attacker-controlled values without any error. The System.Text.Json 10.x package
+            // reference on net8.0/netstandard2.1 makes this option available on every TFM.
+            // Note: STJ enforces this option only in its built-in object mapper. Converters registered below
+            // that hand-parse JSON (Reserve, Asset, AssetAmount, LiquidityPoolClaimableAssetAmount, Predicate,
+            // Link) enforce the same rule themselves via JsonDuplicatePropertyGuard. The polymorphic
+            // OperationResponse/EffectResponse converters hand-parse only the type_i discriminator and then
+            // re-deserialize through the mapper, so duplicates on their fields are still rejected by this option.
             AllowDuplicateProperties = false,
 
             // Enforce C# nullability annotations so null values for non-nullable properties are rejected
@@ -85,7 +95,8 @@ public static class JsonOptions
         // Freeze the options to prevent accidental modification of the shared singleton.
         // populateMissingResolver: true installs the default reflection-based TypeInfoResolver,
         // which matches the SDK's existing serialization behavior.
-        // STJ 8.0+ (including netstandard2.1 via package 8.0.5) provides MakeReadOnly(bool).
+        // STJ 8.0+ provides MakeReadOnly(bool) — satisfied on every TFM (built-in STJ 10 on net10.0;
+        // the System.Text.Json 10.x package on net8.0/netstandard2.1).
         options.MakeReadOnly(true);
         return options;
     }

--- a/StellarDotnetSdk/Converters/LinkJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/LinkJsonConverter.cs
@@ -12,6 +12,11 @@ namespace StellarDotnetSdk.Converters;
 /// <typeparam name="T">The response type this link refers to</typeparam>
 /// <remarks>
 ///     Performance: Uses direct instantiation (no reflection) for Native AOT compatibility.
+///     Duplicate JSON property names are always rejected with a <see cref="JsonException" />, matched
+///     case-insensitively. This is intentional hardening for pagination hrefs and does not honor the
+///     <see cref="JsonSerializerOptions" /> passed to <see cref="Read" /> — neither
+///     <see cref="JsonSerializerOptions.AllowDuplicateProperties" /> nor
+///     <see cref="JsonSerializerOptions.PropertyNameCaseInsensitive" /> changes it.
 /// </remarks>
 public class LinkJsonConverter<T> : JsonConverter<Link<T>> where T : Response
 {
@@ -26,6 +31,7 @@ public class LinkJsonConverter<T> : JsonConverter<Link<T>> where T : Response
 
         using var jsonDocument = JsonDocument.ParseValue(ref reader);
         var jsonObject = jsonDocument.RootElement;
+        JsonDuplicatePropertyGuard.EnsureNoDuplicateProperties(jsonObject, $"Link<{typeof(T).Name}>");
 
         // Read templated property (optional, defaults to false)
         var templated = jsonObject.TryGetProperty("templated", out var templatedElement)

--- a/StellarDotnetSdk/Converters/LiquidityPoolClaimableAssetAmountJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/LiquidityPoolClaimableAssetAmountJsonConverter.cs
@@ -10,6 +10,13 @@ namespace StellarDotnetSdk.Converters;
 ///     JSON converter for LiquidityPoolClaimableAssetAmount.
 ///     Handles conversion between JSON objects and LiquidityPoolClaimableAssetAmount instances.
 /// </summary>
+/// <remarks>
+///     Duplicate JSON property names are always rejected with a <see cref="JsonException" />, matched
+///     case-insensitively. This is intentional hardening for financial fields and does not honor the
+///     <see cref="JsonSerializerOptions" /> passed to <see cref="Read" /> — neither
+///     <see cref="JsonSerializerOptions.AllowDuplicateProperties" /> nor
+///     <see cref="JsonSerializerOptions.PropertyNameCaseInsensitive" /> changes it.
+/// </remarks>
 public class LiquidityPoolClaimableAssetAmountJsonConverter : JsonConverter<LiquidityPoolClaimableAssetAmount>
 {
     /// <inheritdoc />
@@ -27,6 +34,8 @@ public class LiquidityPoolClaimableAssetAmountJsonConverter : JsonConverter<Liqu
 
         using var jsonDocument = JsonDocument.ParseValue(ref reader);
         var jsonObject = jsonDocument.RootElement;
+        JsonDuplicatePropertyGuard.EnsureNoDuplicateProperties(jsonObject,
+            nameof(LiquidityPoolClaimableAssetAmount));
 
         if (!jsonObject.TryGetProperty("asset", out var assetElement))
         {

--- a/StellarDotnetSdk/Converters/LiquidityPoolClaimableAssetAmountJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/LiquidityPoolClaimableAssetAmountJsonConverter.cs
@@ -52,7 +52,7 @@ public class LiquidityPoolClaimableAssetAmountJsonConverter : JsonConverter<Liqu
             throw new JsonException($"JSON value for amount is missing in {nameof(LiquidityPoolClaimableAssetAmount)}.");
         }
         var amount = amountElement.GetString();
-        if (amount == null)
+        if (string.IsNullOrEmpty(amount))
         {
             throw new JsonException($"JSON value for amount is missing in {nameof(LiquidityPoolClaimableAssetAmount)}.");
         }

--- a/StellarDotnetSdk/Converters/LiquidityPoolClaimableAssetAmountJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/LiquidityPoolClaimableAssetAmountJsonConverter.cs
@@ -39,16 +39,23 @@ public class LiquidityPoolClaimableAssetAmountJsonConverter : JsonConverter<Liqu
 
         if (!jsonObject.TryGetProperty("asset", out var assetElement))
         {
-            throw new ArgumentException("JSON value for asset is missing.", nameof(assetElement));
+            throw new JsonException($"JSON value for asset is missing in {nameof(LiquidityPoolClaimableAssetAmount)}.");
         }
         var assetName = assetElement.GetString();
-        var asset = string.IsNullOrEmpty(assetName) ? null : Asset.Create(assetName);
+        if (string.IsNullOrEmpty(assetName))
+        {
+            throw new JsonException($"JSON value for asset is missing in {nameof(LiquidityPoolClaimableAssetAmount)}.");
+        }
 
         if (!jsonObject.TryGetProperty("amount", out var amountElement))
         {
-            throw new ArgumentException("JSON value for amount is missing.", nameof(amountElement));
+            throw new JsonException($"JSON value for amount is missing in {nameof(LiquidityPoolClaimableAssetAmount)}.");
         }
         var amount = amountElement.GetString();
+        if (amount == null)
+        {
+            throw new JsonException($"JSON value for amount is missing in {nameof(LiquidityPoolClaimableAssetAmount)}.");
+        }
 
         // claimable_balance_id is optional
         string? claimableBalanceId = null;
@@ -57,18 +64,9 @@ public class LiquidityPoolClaimableAssetAmountJsonConverter : JsonConverter<Liqu
             claimableBalanceId = claimableBalanceIdElement.GetString();
         }
 
-        if (asset == null)
-        {
-            throw new ArgumentException("JSON value for asset is missing.", nameof(asset));
-        }
-        if (amount == null)
-        {
-            throw new ArgumentException("JSON value for amount is missing.", nameof(amount));
-        }
-
         return new LiquidityPoolClaimableAssetAmount
         {
-            Asset = asset,
+            Asset = AssetJsonReadHelper.CreateAsset(assetName),
             Amount = amount,
             ClaimableBalanceId = claimableBalanceId,
         };

--- a/StellarDotnetSdk/Converters/OperationResponseJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/OperationResponseJsonConverter.cs
@@ -97,6 +97,12 @@ public class OperationResponseJsonConverter : JsonConverter<OperationResponse>
         using var document = JsonDocument.ParseValue(ref reader);
         var root = document.RootElement;
 
+        // The mapper re-parse below rejects duplicates of mapped fields, but type_i is a read-only
+        // (get-only) discriminator the mapper never binds, so a duplicated type_i would otherwise slip
+        // through and be resolved by a single hand-read. Guard the root explicitly so every duplicate —
+        // discriminator included — fails fast, consistent with the SDK's other hand-parsing converters.
+        JsonDuplicatePropertyGuard.EnsureNoDuplicateProperties(root, nameof(OperationResponse));
+
         // Extract discriminator from parsed document
         if (!root.TryGetProperty("type_i", out var typeProperty))
         {

--- a/StellarDotnetSdk/Converters/PredicateJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/PredicateJsonConverter.cs
@@ -85,6 +85,20 @@ public class PredicateJsonConverter : JsonConverter<Predicate>
             if (root.TryGetProperty("abs_before_epoch", out var epochElement))
             {
                 absBeforeEpoch = ReadInt64FromNumberOrString(epochElement, "abs_before_epoch");
+
+                // Horizon renders abs_before and abs_before_epoch as the same instant. If a payload
+                // supplies both and they disagree, a spoofed epoch could silently shift the claim
+                // deadline while the human-readable string still looks correct (the DateTime accessor
+                // prefers the epoch), so reject the contradiction instead of trusting one side.
+                if (DateTimeOffset.TryParse(absBefore, CultureInfo.InvariantCulture,
+                        DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                        out var parsedAbsBefore)
+                    && parsedAbsBefore.ToUnixTimeSeconds() != absBeforeEpoch.Value)
+                {
+                    throw new JsonException(
+                        $"Property 'abs_before_epoch' ({absBeforeEpoch.Value}) does not match " +
+                        $"'abs_before' ({absBefore}); they must denote the same instant.");
+                }
             }
 
             return new PredicateBeforeAbsoluteTime(absBefore, absBeforeEpoch);
@@ -155,24 +169,37 @@ public class PredicateJsonConverter : JsonConverter<Predicate>
     }
 
     /// <summary>
-    ///     Reads a 64-bit integer that Horizon emits either as a JSON number or as a numeric string.
-    ///     Every malformed value becomes a <see cref="JsonException" /> (the SDK's documented failure mode)
-    ///     rather than a leaked <see cref="FormatException" /> or <see cref="OverflowException" />.
+    ///     Reads a non-negative 64-bit integer that Horizon emits either as a JSON number or as a numeric
+    ///     string. Every malformed value becomes a <see cref="JsonException" /> (the SDK's documented
+    ///     failure mode) rather than a leaked <see cref="FormatException" /> or
+    ///     <see cref="OverflowException" />. Stellar time bounds are unsigned, so a negative value is
+    ///     rejected as well.
     /// </summary>
     private static long ReadInt64FromNumberOrString(JsonElement element, string propertyName)
     {
+        long value;
         switch (element.ValueKind)
         {
             case JsonValueKind.String
                 when long.TryParse(element.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture,
                     out var parsed):
-                return parsed;
+                value = parsed;
+                break;
             case JsonValueKind.Number when element.TryGetInt64(out var number):
-                return number;
+                value = number;
+                break;
             default:
                 throw new JsonException(
                     $"Property '{propertyName}' must be a 64-bit integer or a numeric string containing one.");
         }
+
+        if (value < 0)
+        {
+            throw new JsonException(
+                $"Property '{propertyName}' must not be negative; Stellar time bounds are unsigned.");
+        }
+
+        return value;
     }
 
     private static Predicate[] DeserializePredicateArray(JsonElement element, JsonSerializerOptions options,

--- a/StellarDotnetSdk/Converters/PredicateJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/PredicateJsonConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using StellarDotnetSdk.Responses.Predicates;
@@ -21,6 +22,13 @@ namespace StellarDotnetSdk.Converters;
 ///         <item><c>{"abs_before": "...", "abs_before_epoch": ...}</c> → <see cref="PredicateBeforeAbsoluteTime" /></item>
 ///         <item><c>{"rel_before": ...}</c> → <see cref="PredicateBeforeRelativeTime" /></item>
 ///     </list>
+///     <para>
+///         Duplicate JSON property names are always rejected with a <see cref="JsonException" />, matched
+///         case-insensitively, at every nesting level. This is intentional hardening for time-lock
+///         predicates and does not honor the <see cref="JsonSerializerOptions" /> passed to
+///         <see cref="Read" /> — neither <see cref="JsonSerializerOptions.AllowDuplicateProperties" />
+///         nor <see cref="JsonSerializerOptions.PropertyNameCaseInsensitive" /> changes it.
+///     </para>
 /// </remarks>
 public class PredicateJsonConverter : JsonConverter<Predicate>
 {
@@ -30,29 +38,19 @@ public class PredicateJsonConverter : JsonConverter<Predicate>
     {
         using var document = JsonDocument.ParseValue(ref reader);
         var root = document.RootElement;
+        // Nested predicates re-enter this converter, so each recursion level checks its own object.
+        JsonDuplicatePropertyGuard.EnsureNoDuplicateProperties(root, nameof(Predicate));
 
         // Determine type by which property is present
         if (root.TryGetProperty("and", out var andElement))
         {
-            var predicates = DeserializePredicateArray(andElement, options);
-            if (predicates.Length < 2)
-            {
-                throw new JsonException(
-                    "Property 'and' must contain at least 2 predicates.");
-            }
-
+            var predicates = DeserializePredicateArray(andElement, options, "and");
             return new PredicateAnd(predicates[0], predicates[1]);
         }
 
         if (root.TryGetProperty("or", out var orElement))
         {
-            var predicates = DeserializePredicateArray(orElement, options);
-            if (predicates.Length < 2)
-            {
-                throw new JsonException(
-                    "Property 'or' must contain at least 2 predicates.");
-            }
-
+            var predicates = DeserializePredicateArray(orElement, options, "or");
             return new PredicateOr(predicates[0], predicates[1]);
         }
 
@@ -86,9 +84,7 @@ public class PredicateJsonConverter : JsonConverter<Predicate>
             long? absBeforeEpoch = null;
             if (root.TryGetProperty("abs_before_epoch", out var epochElement))
             {
-                absBeforeEpoch = epochElement.ValueKind == JsonValueKind.String
-                    ? long.Parse(epochElement.GetString()!)
-                    : epochElement.GetInt64();
+                absBeforeEpoch = ReadInt64FromNumberOrString(epochElement, "abs_before_epoch");
             }
 
             return new PredicateBeforeAbsoluteTime(absBefore, absBeforeEpoch);
@@ -96,9 +92,7 @@ public class PredicateJsonConverter : JsonConverter<Predicate>
 
         if (root.TryGetProperty("rel_before", out var relBeforeElement))
         {
-            var relBefore = relBeforeElement.ValueKind == JsonValueKind.String
-                ? long.Parse(relBeforeElement.GetString()!)
-                : relBeforeElement.GetInt64();
+            var relBefore = ReadInt64FromNumberOrString(relBeforeElement, "rel_before");
 
             return new PredicateBeforeRelativeTime(relBefore);
         }
@@ -160,9 +154,45 @@ public class PredicateJsonConverter : JsonConverter<Predicate>
         writer.WriteEndObject();
     }
 
-    private static Predicate[] DeserializePredicateArray(JsonElement element, JsonSerializerOptions options)
+    /// <summary>
+    ///     Reads a 64-bit integer that Horizon emits either as a JSON number or as a numeric string.
+    ///     Every malformed value becomes a <see cref="JsonException" /> (the SDK's documented failure mode)
+    ///     rather than a leaked <see cref="FormatException" /> or <see cref="OverflowException" />.
+    /// </summary>
+    private static long ReadInt64FromNumberOrString(JsonElement element, string propertyName)
     {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.String
+                when long.TryParse(element.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture,
+                    out var parsed):
+                return parsed;
+            case JsonValueKind.Number when element.TryGetInt64(out var number):
+                return number;
+            default:
+                throw new JsonException(
+                    $"Property '{propertyName}' must be a 64-bit integer or a numeric string containing one.");
+        }
+    }
+
+    private static Predicate[] DeserializePredicateArray(JsonElement element, JsonSerializerOptions options,
+        string propertyName)
+    {
+        if (element.ValueKind != JsonValueKind.Array)
+        {
+            throw new JsonException($"Property '{propertyName}' must be an array of exactly 2 predicates.");
+        }
+
+        // Validate the arity before touching any element: Stellar's ClaimPredicate AND/OR are strictly
+        // binary (extra elements used to be dropped silently), and checking first also stops an
+        // oversized array from being fully materialized.
         var length = element.GetArrayLength();
+        if (length != 2)
+        {
+            throw new JsonException(
+                $"Property '{propertyName}' must contain exactly 2 predicates, but found {length}.");
+        }
+
         var result = new Predicate[length];
         var index = 0;
         foreach (var item in element.EnumerateArray())

--- a/StellarDotnetSdk/Converters/ReserveJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/ReserveJsonConverter.cs
@@ -67,15 +67,15 @@ public class ReserveJsonConverter : JsonConverter<Reserve>
 
         if (string.IsNullOrEmpty(assetName))
         {
-            throw new ArgumentException("JSON value for asset is missing.", nameof(assetName));
+            throw new JsonException($"JSON value for asset is missing in {nameof(Reserve)}.");
         }
 
         if (string.IsNullOrEmpty(amount))
         {
-            throw new ArgumentException("JSON value for amount is missing.", nameof(amount));
+            throw new JsonException($"JSON value for amount is missing in {nameof(Reserve)}.");
         }
 
-        var asset = Asset.Create(assetName);
+        var asset = AssetJsonReadHelper.CreateAsset(assetName);
 
         return new Reserve
         {

--- a/StellarDotnetSdk/Converters/ReserveJsonConverter.cs
+++ b/StellarDotnetSdk/Converters/ReserveJsonConverter.cs
@@ -10,6 +10,13 @@ namespace StellarDotnetSdk.Converters;
 ///     JSON converter for Reserve.
 ///     Handles conversion between JSON objects and Reserve instances.
 /// </summary>
+/// <remarks>
+///     Duplicate JSON property names are always rejected with a <see cref="JsonException" />, matched
+///     case-insensitively. This is intentional hardening for financial fields and does not honor the
+///     <see cref="JsonSerializerOptions" /> passed to <see cref="Read" /> — neither
+///     <see cref="JsonSerializerOptions.AllowDuplicateProperties" /> nor
+///     <see cref="JsonSerializerOptions.PropertyNameCaseInsensitive" /> changes it.
+/// </remarks>
 public class ReserveJsonConverter : JsonConverter<Reserve>
 {
     /// <inheritdoc />
@@ -26,6 +33,7 @@ public class ReserveJsonConverter : JsonConverter<Reserve>
 
         string? assetName = null;
         string? amount = null;
+        var seen = JsonDuplicatePropertyGuard.CreateSeenSet();
 
         while (reader.Read())
         {
@@ -36,7 +44,8 @@ public class ReserveJsonConverter : JsonConverter<Reserve>
 
             if (reader.TokenType == JsonTokenType.PropertyName)
             {
-                var propertyName = reader.GetString();
+                var propertyName = reader.GetString()!;
+                JsonDuplicatePropertyGuard.MarkSeen(seen, propertyName, nameof(Reserve));
                 reader.Read();
                 switch (propertyName)
                 {
@@ -45,6 +54,12 @@ public class ReserveJsonConverter : JsonConverter<Reserve>
                         break;
                     case "amount":
                         amount = reader.GetString();
+                        break;
+                    default:
+                        // Skip the whole value: an unrecognized object/array value would otherwise be
+                        // walked as if its keys were top-level Reserve properties, corrupting the
+                        // duplicate guard's seen-set and desynchronizing the reader.
+                        reader.Skip();
                         break;
                 }
             }

--- a/StellarDotnetSdk/Responses/Predicates/PredicateBeforeAbsoluteTime.cs
+++ b/StellarDotnetSdk/Responses/Predicates/PredicateBeforeAbsoluteTime.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using ClaimPredicate = StellarDotnetSdk.Claimants.ClaimPredicate;
 
 namespace StellarDotnetSdk.Responses.Predicates;
@@ -33,9 +34,16 @@ public sealed class PredicateBeforeAbsoluteTime : Predicate
     /// <summary>
     ///     Gets the deadline as a <see cref="DateTimeOffset" />.
     /// </summary>
+    /// <remarks>
+    ///     When no epoch is available, <see cref="AbsBefore" /> is parsed with the invariant culture and a
+    ///     value without an offset designator is interpreted as UTC — the same rules the
+    ///     <see cref="Converters.PredicateJsonConverter" /> consistency check applies — so the deadline
+    ///     resolves to the same instant regardless of the machine's culture or local time zone.
+    /// </remarks>
     public DateTimeOffset DateTime => AbsBeforeEpoch.HasValue
         ? DateTimeOffset.FromUnixTimeSeconds(AbsBeforeEpoch.Value)
-        : DateTimeOffset.Parse(AbsBefore);
+        : DateTimeOffset.Parse(AbsBefore, CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
 
     /// <inheritdoc />
     public override ClaimPredicate ToClaimPredicate()

--- a/StellarDotnetSdk/Sep/Sep0009/KycJsonOptions.cs
+++ b/StellarDotnetSdk/Sep/Sep0009/KycJsonOptions.cs
@@ -30,9 +30,7 @@ public static class KycJsonOptions
         {
             PropertyNameCaseInsensitive = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-#if NET10_0_OR_GREATER
             RespectNullableAnnotations = true,
-#endif
 #if !NETSTANDARD2_1
             Converters =
             {

--- a/StellarDotnetSdk/Sep/Sep0009/KycJsonOptions.cs
+++ b/StellarDotnetSdk/Sep/Sep0009/KycJsonOptions.cs
@@ -30,6 +30,10 @@ public static class KycJsonOptions
         {
             PropertyNameCaseInsensitive = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            // Reject KYC payloads with duplicate property names (last-write-wins would otherwise let a
+            // malformed/adversarial record silently overwrite a field). Matches JsonOptions.DefaultOptions;
+            // available on every TFM via the System.Text.Json 10.x reference on net8.0/netstandard2.1.
+            AllowDuplicateProperties = false,
             RespectNullableAnnotations = true,
 #if !NETSTANDARD2_1
             Converters =

--- a/StellarDotnetSdk/Sep/Sep0045/ChallengeForContractsResponse.cs
+++ b/StellarDotnetSdk/Sep/Sep0045/ChallengeForContractsResponse.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using StellarDotnetSdk.Converters;
 
 namespace StellarDotnetSdk.Sep.Sep0045;
 
@@ -27,9 +27,10 @@ public sealed record ChallengeForContractsResponse
 /// <remarks>
 ///     This response is an adversarial-server surface (its <c>authorization_entries</c> blob is what the
 ///     client signs), so the converter preserves the SDK-wide duplicate-property guard
-///     (<see cref="StellarDotnetSdk.Converters.JsonOptions" /> sets <c>AllowDuplicateProperties = false</c>):
-///     a raw <see cref="JsonDocument" /> is last-wins by default, so duplicates are rejected explicitly
-///     here (case-insensitively, like the SDK's guard) rather than silently overriding the signed blob.
+///     (<see cref="JsonOptions" /> sets <c>AllowDuplicateProperties = false</c>):
+///     a raw <see cref="JsonDocument" /> is last-wins by default, so duplicates are rejected via
+///     <see cref="JsonDuplicatePropertyGuard" /> (case-insensitively, like the SDK's guard) rather than
+///     silently overriding the signed blob.
 ///     Value lookup itself remains exact-name (snake/camel), mirroring the peer SDK's two-key lookup.
 /// </remarks>
 internal sealed class ChallengeForContractsResponseConverter : JsonConverter<ChallengeForContractsResponse>
@@ -44,21 +45,15 @@ internal sealed class ChallengeForContractsResponseConverter : JsonConverter<Cha
             return new ChallengeForContractsResponse();
         }
 
+        // Reject duplicate property names — a raw JsonDocument is last-wins, which would otherwise
+        // bypass the AllowDuplicateProperties = false guard the SDK applies to every other response.
+        JsonDuplicatePropertyGuard.EnsureNoDuplicateProperties(root, "SEP-45 challenge response");
+
         string? snakeAuthorizationEntries = null, camelAuthorizationEntries = null;
         string? snakeNetworkPassphrase = null, camelNetworkPassphrase = null;
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var property in root.EnumerateObject())
         {
-            // Reject duplicate property names (case-insensitively, matching the SDK's case-insensitive
-            // property matching) — a raw JsonDocument is last-wins, which would otherwise bypass the
-            // AllowDuplicateProperties = false guard the SDK applies to every other response.
-            if (!seen.Add(property.Name))
-            {
-                throw new JsonException(
-                    $"Duplicate property '{property.Name}' in SEP-45 challenge response.");
-            }
-
             if (property.Value.ValueKind != JsonValueKind.String)
             {
                 continue;

--- a/StellarDotnetSdk/StellarDotnetSdk.csproj
+++ b/StellarDotnetSdk/StellarDotnetSdk.csproj
@@ -37,10 +37,11 @@
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
         <PackageReference Include="Sodium.Core" Version="1.4.1" />
-        <PackageReference Include="System.Text.Json" Version="8.0.5" />
+        <PackageReference Include="System.Text.Json" Version="10.0.6" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
         <PackageReference Include="NSec.Cryptography" Version="25.4.0" />
+        <PackageReference Include="System.Text.Json" Version="10.0.6" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
         <PackageReference Include="NSec.Cryptography" Version="26.4.0" />


### PR DESCRIPTION
Follow-up to #195, addressing [this post-merge review finding](https://github.com/Beans-BV/dotnet-stellar-sdk/pull/195#discussion_r3513425655). Split into its own PR because it deliberately revisits a dependency decision made during the #195 review — keeping it isolated makes the trade-off visible and the change trivially revertible.

## What

Reference the standalone **System.Text.Json 10.0.6** package on `net8.0` and `netstandard2.1` (net10.0 already uses the built-in STJ 10), and make `AllowDuplicateProperties = false` + `RespectNullableAnnotations = true` unconditional in `JsonOptions.DefaultOptions` and `KycJsonOptions.Default`. The previously net10-only guard tests now run — and pass — on all three TFMs.

## Why

The released `16.0.0-beta` (single-target net8.0) referenced STJ 10.x and had both protections. During the #195 review the package reference was removed to avoid forcing a dependency floor on net8 consumers — which silently downgraded them: a payload carrying a duplicate JSON property (e.g. two `amount` fields) deserializes **last-write-wins** on net8.0/netstandard2.1 while net10.0 throws. Duplicate keys are a classic parser-differential vector, and what this SDK parses is balances, amounts, and asset codes from Horizon/anchor responses.

Since no stable release ever shipped without the STJ 10.x reference, restoring it does not break any released dependency expectation — it restores the released beta's behavior and extends it uniformly to netstandard2.1.

## Trade-off (the reason this is a separate PR)

`net8.0`/`netstandard2.1` consumers inherit a transitive `System.Text.Json >= 10.0.6` floor. Apps pinned to STJ 8.x/9.x get forced upgrades or NuGet downgrade warnings, and hosts that pin STJ themselves can conflict. If that cost turns out to bite, reverting this single PR restores the guarded (net10-only) behavior without touching anything else.

## Verification

Full unit suites green on this branch standalone (main + this change only): net10.0 **1942**, net8.0 **1932**, netstandard2.1-via-net8-host **1929** passed, 0 failures — including the duplicate-property and nullability rejection tests now running on every leg. Merges cleanly with the companion hardening PR #202 in either order (union verified byte-identical to the tree both were developed in).
